### PR TITLE
fix broken kali ami search

### DIFF
--- a/terraform/modules/kali_machine/resources.tf
+++ b/terraform/modules/kali_machine/resources.tf
@@ -1,11 +1,11 @@
 
 data "aws_ami" "latest-kali-linux" {
-most_recent = true
-owners = ["679593333241"] # Canonical
+  most_recent = true
+  owners = ["679593333241"] # Kali Linux (https://www.kali.org/about-us/)
 
   filter {
       name   = "name"
-      values = ["Kali Linux 2018.1-*"]
+      values = ["Kali Linux 2019.*"]
   }
 
   filter {


### PR DESCRIPTION
The first data step in resources.tf for the Kali machine was failing to find an AMI, maybe because it was removed from AWS recently. Even though I wasn't  trying to even build Kali it was causing terraform builds to fail. I updated the image name we are searching for to find the 2019.4 image which does exist right now, so this step will pass.