### PR TITLE
Attach uuid to hostnames

### DIFF
--- a/ansible/playbooks/splunk_server.yml
+++ b/ansible/playbooks/splunk_server.yml
@@ -1,7 +1,10 @@
 - hosts: all
   gather_facts: False
   become: true
+  vars:  
+    hostname: splunk-server
   roles:
+    - linux_common
     - search_head
     - splunk_phantom
     - splunk_phantom_configure

--- a/ansible/roles/linux_common/tasks/main.yml
+++ b/ansible/roles/linux_common/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include: set-hostname.yml

--- a/ansible/roles/linux_common/tasks/set-hostname.yml
+++ b/ansible/roles/linux_common/tasks/set-hostname.yml
@@ -2,4 +2,4 @@
 
 - name: Change the hostname
   hostname:
-    name: "{{ hostname }}-{{ hostname | to_uuid }}"
+    name: "{{ hostname }}-{{ 9999999 | random }}"

--- a/ansible/roles/linux_common/tasks/set-hostname.yml
+++ b/ansible/roles/linux_common/tasks/set-hostname.yml
@@ -1,5 +1,5 @@
 ---
 
 - name: Change the hostname
-  win_hostname:
+  hostname:
     name: "{{ hostname }}-{{ hostname | to_uuid }}"

--- a/ansible/roles/windows_common/tasks/set-hostname.yml
+++ b/ansible/roles/windows_common/tasks/set-hostname.yml
@@ -2,4 +2,4 @@
 
 - name: Change the hostname
   win_hostname:
-    name: "{{ hostname }}-{{ hostname | to_uuid }}"
+    name: "{{ hostname }}-{{ 9999999 | random }}"


### PR DESCRIPTION
Adds UUID to hostnames to identify whose attack_range data comes from when it's forwarded to shared environments.