### PR TITLE
adding a wait for test simulation since things time out

### DIFF
--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -67,6 +67,10 @@ class TerraformController(IEnvironmentController):
 
         # build attack range
         self.build()
+        
+        # wait
+        self.log.info('Wait for 300 seconds before running simulations.')
+        time.sleep(300)
 
         # simulate attack
         self.simulate(test_file['target'], test_file['simulation_technique'])


### PR DESCRIPTION
Usually times out due to the windows machine now being up fully yet: https://app.circleci.com/pipelines/github/splunk/security-content/2460/workflows/f46c4576-5559-4bf8-9ed7-736dcffd91e4/jobs/6910