### PR TITLE
[AR-302] add ansible logic for explicit DNS server in resolv.conf

### DIFF
--- a/ansible/roles/search_head/tasks/splunk.yml
+++ b/ansible/roles/search_head/tasks/splunk.yml
@@ -18,6 +18,14 @@
    - install
   file: path=/opt mode=777
 
+- name: Explicit DNS setup on 8.8.8.8
+  tags:
+   - install
+  shell: echo nameserver 8.8.8.8 >> /etc/resolv.conf
+  become: yes
+  become_user: root
+
+
 - name: checking if splunk is install
   tags: install
   stat: path=/opt/splunk


### PR DESCRIPTION
I think its best to just use the ansible fix for now could not get vagrant specific settings to work.