### PR TITLE
Added a Range Name config and launch variable to make multiple range environments easier.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+#state directories
+terraform/state/*
+!terraform/state/state.md

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ python attack_range.py -a dump -dn data_dump
 - [Kali Linux](https://www.kali.org/)
   * Preconfigured Kali Linux machine for penetration testing
   * ssh connection over configured ssh key
-
+- Multiple instances of Attack Range can be launched utilizing the `-rn` parameter for  `attack_range.py`
+  * This will create instances tagged with `${range_name}-${instance_name}`
+  * Depending on how many instance you launch, you may need to increase your ElasticIP quota with the directions [here](https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html)
 
 ## Support 📞
 Please use the [GitHub issue tracker](https://github.com/splunk/attack_range/issues) to submit bugs or request features.
@@ -173,3 +175,4 @@ We welcome feedback and contributions from the community! Please see our [contri
 * Rico Valdez
 * [Dimitris Lambrou](https://twitter.com/etz69)
 * [Dave Herrald](https://twitter.com/daveherrald)
+* Josef Kuepker

--- a/attack_range.conf
+++ b/attack_range.conf
@@ -27,6 +27,12 @@ region = us-west-2
 # please ensure that aws_cli has the same region specified
 # This is only needed for modes: terraform and packer
 
+range_name = default
+# Specify a unique name for the assets in a region
+# Setting this allows you to deploy additional ranges with the same key_name
+# An example would be for user1 and user2 testing in seperate environments
+#or user1 testing multiple use cases
+
 
 [splunk_settings]
 splunk_admin_password = I-l1ke-Attack-Range!

--- a/attack_range.py
+++ b/attack_range.py
@@ -16,9 +16,12 @@ VERSION = 1
 
 if __name__ == "__main__":
     # grab arguments
-    parser = argparse.ArgumentParser(description="starts a attack range ready to collect attack data into splunk")
+    parser = argparse.ArgumentParser(
+        description="starts a attack range ready to collect attack data into splunk")
     parser.add_argument("-a", "--action", required=False, choices=['build', 'destroy', 'simulate', 'stop', 'resume', 'test', 'dump'], default="",
                         help="action to take on the range, defaults to \"build\", build/destroy/simulate/stop/resume/search allowed")
+    parser.add_argument("-rn", "--range_name", required=False,
+                        help="name of the range you would like to manages")
     parser.add_argument("-t", "--target", required=False,
                         help="target for attack simulation. Use the name of the aws EC2 name")
     parser.add_argument("-st", "--simulation_technique", required=False, type=str, default="",
@@ -29,8 +32,10 @@ if __name__ == "__main__":
                         help="name for the dumped attack data")
     parser.add_argument("-c", "--config", required=False, default="attack_range.conf",
                         help="path to the configuration file of the attack range")
-    parser.add_argument("-tf", "--test_file", required=False, type=str, default="", help='test file for test command')
-    parser.add_argument("-lm", "--list_machines", required=False, default=False, action="store_true", help="prints out all available machines")
+    parser.add_argument("-tf", "--test_file", required=False,
+                        type=str, default="", help='test file for test command')
+    parser.add_argument("-lm", "--list_machines", required=False, default=False,
+                        action="store_true", help="prints out all available machines")
     parser.add_argument("-v", "--version", default=False, action="store_true", required=False,
                         help="shows current attack_range version")
 
@@ -40,6 +45,7 @@ if __name__ == "__main__":
     action = args.action
     target = args.target
     config = args.config
+    range_name = args.range_name
     simulation_techniques = args.simulation_technique
     simulation_atomics = args.simulation_atomics
     list_machines = args.list_machines
@@ -67,10 +73,12 @@ starting program loaded for B1 battle droid
     # parse config
     attack_range_config = Path(config)
     if attack_range_config.is_file():
-        print("attack_range is using config at path {0}".format(attack_range_config))
+        print("attack_range is using config at path {0}".format(
+            attack_range_config))
         configpath = str(attack_range_config)
     else:
-        print("ERROR: attack_range failed to find a config file at {0} or {1}..exiting".format(attack_range_config))
+        print("ERROR: attack_range failed to find a config file at {0} or {1}..exiting".format(
+            attack_range_config))
         sys.exit(1)
 
     # Parse config
@@ -96,6 +104,11 @@ starting program loaded for B1 battle droid
         log.error('ERROR: flag --action is needed.')
         sys.exit(1)
 
+    # replace with custom range_name (-rn) if specified
+    if range_name:
+        config["range_name"] = range_name
+    else:
+        pass
 
     # lets give CLI priority over config file for pre-configured techniques
     if simulation_techniques:

--- a/modules/CustomConfigParser.py
+++ b/modules/CustomConfigParser.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 import re
 
+
 class CustomConfigParser:
     def __init__(self):
         self.settings = {}
@@ -16,32 +17,43 @@ class CustomConfigParser:
 
         key_name_regex = re.compile('[@!#$%^&*()\' <>?/\|}{~:]')
         if (key_name_regex.search(self.settings['key_name']) != None):
-            print("ERROR - with configuration file at: {0}, no special characters, spaces, single quotes allowed in key_name: {1}".format(CONFIG_PATH,self.settings['key_name']))
+            print("ERROR - with configuration file at: {0}, no special characters, spaces, single quotes allowed in key_name: {1}".format(
+                CONFIG_PATH, self.settings['key_name']))
+            sys.exit(1)
+
+        range_name_regex = re.compile('[@!#$%^&*()\' <>?/\|}{~:]')
+        if (range_name_regex.search(self.settings['range_name']) != None):
+            print("ERROR - with configuration file at: {0}, no special characters, spaces, single quotes allowed in range_name: {1}".format(
+                CONFIG_PATH, self.settings['range_name']))
             sys.exit(1)
 
         # Check for disallowed BOTS dataset combinations or syntax
         if self.settings['splunk_bots_dataset'] != '0':
             allowed_bots_data_sets = ('1', '1a', '2', '2a', '3')
-            requested_bots_data_sets = [x.strip() for x in str(self.settings['splunk_bots_dataset']).split(',')]
+            requested_bots_data_sets = [x.strip() for x in str(
+                self.settings['splunk_bots_dataset']).split(',')]
             for requested_bots_dataset in requested_bots_data_sets:
                 if requested_bots_dataset not in allowed_bots_data_sets:
-                    print("ERROR - in configuration file: {0}, unknown BOTS dataset identifier: {1}".format(CONFIG_PATH, requested_bots_dataset))
+                    print("ERROR - in configuration file: {0}, unknown BOTS dataset identifier: {1}".format(
+                        CONFIG_PATH, requested_bots_dataset))
                     sys.exit(1)
 
             if '1' in requested_bots_data_sets and '1a' in requested_bots_data_sets:
-                print("ERROR - in configuration file: {0}, cannot include datasets '1' and '1a'".format(CONFIG_PATH))
+                print(
+                    "ERROR - in configuration file: {0}, cannot include datasets '1' and '1a'".format(CONFIG_PATH))
                 sys.exit(1)
 
             if '2' in requested_bots_data_sets and '2a' in requested_bots_data_sets:
-                print("ERROR - in configuration file: {0}, cannot include datasets '2' and '2a'".format(CONFIG_PATH))
+                print(
+                    "ERROR - in configuration file: {0}, cannot include datasets '2' and '2a'".format(CONFIG_PATH))
                 sys.exit(1)
 
             if bool(re.search(r"\s", self.settings['splunk_bots_dataset'])):
-                print("ERROR - in configuration file: {0}, cannot include whitespace in BOTS data set config directive.".format(CONFIG_PATH))
+                print(
+                    "ERROR - in configuration file: {0}, cannot include whitespace in BOTS data set config directive.".format(CONFIG_PATH))
                 sys.exit(1)
 
-
-    def load_conf(self,CONFIG_PATH):
+    def load_conf(self, CONFIG_PATH):
         """Provided a config file path and a collections of type dict,
         will return that collections with all the settings in it"""
 
@@ -52,7 +64,8 @@ class CustomConfigParser:
                 try:
                     self.settings[key] = config.get(section, key)
                 except Exception as e:
-                    print("ERROR - with configuration file at {0} failed with error {1}".format(CONFIG_PATH, e))
+                    print(
+                        "ERROR - with configuration file at {0} failed with error {1}".format(CONFIG_PATH, e))
                     sys.exit(1)
         self._config_rules(CONFIG_PATH)
 

--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -9,41 +9,51 @@ import time
 import tarfile
 import os
 import glob
+import sys
 
 
 class TerraformController(IEnvironmentController):
 
     def __init__(self, config, log):
         super().__init__(config, log)
+        statefile = self.config['range_name'] + ".terraform.tfstate"
+        config["statepath"] = os.path.join(
+            'state', statefile)
         custom_dict = self.config.copy()
         variables = dict()
         variables['config'] = custom_dict
-        self.terraform = Terraform(working_dir='terraform',variables=variables)
-
+        self.terraform = Terraform(
+            working_dir='terraform', variables=variables, parallelism=15 ,state=config["statepath"])
 
     def build(self):
         self.log.info("[action] > build\n")
-        return_code, stdout, stderr = self.terraform.apply(capture_output='yes', skip_plan=True, no_color=IsNotFlagged)
+        return_code, stdout, stderr = self.terraform.apply(
+            capture_output='yes', skip_plan=True, no_color=IsNotFlagged)
         if not return_code:
-           self.log.info("attack_range has been built using terraform successfully")
-           self.list_machines()
-
+            self.log.info(
+                "attack_range has been built using terraform successfully")
+            self.list_machines()
 
     def destroy(self):
         self.log.info("[action] > destroy\n")
-        return_code, stdout, stderr = self.terraform.destroy(capture_output='yes', no_color=IsNotFlagged)
-        self.log.info("attack_range has been destroy using terraform successfully")
-
+        return_code, stdout, stderr = self.terraform.destroy(
+            capture_output='yes', no_color=IsNotFlagged)
+        self.log.info("Destroyed with return code: " + str(return_code))
+        statepath = "terraform/" + self.config["statepath"]
+        statebakpath = "terraform/" + self.config["statepath"] + ".backup"
+        if os.path.exists(statepath) and return_code==0:
+            os.remove(statepath)
+            os.remove(statebakpath)
+        self.log.info(
+            "attack_range has been destroy using terraform successfully")
 
     def stop(self):
         instances = aws_service.get_all_instances(self.config)
-        aws_service.change_ec2_state(instances, 'stopped', self.log)
-
+        aws_service.change_ec2_state(instances, 'stopped', self.log, self.config)
 
     def resume(self):
         instances = aws_service.get_all_instances(self.config)
-        aws_service.change_ec2_state(instances, 'running', self.log)
-
+        aws_service.change_ec2_state(instances, 'running', self.log, self.config)
 
     def test(self, test_file):
         # read test file
@@ -62,7 +72,7 @@ class TerraformController(IEnvironmentController):
             var_str = '$myArgs = @{ '
             i = 0
             for key, value in test_file['vars'].items():
-                if i==0:
+                if i == 0:
                     var_str += '"' + key + '" = "' + value + '"'
                     i += 1
                 else:
@@ -72,10 +82,12 @@ class TerraformController(IEnvironmentController):
             var_str += ' }'
             print(var_str)
 
-            self.simulate(test_file['target'], test_file['simulation_technique'], 'no', var_str)
+            self.simulate(
+                test_file['target'], test_file['simulation_technique'], 'no', var_str)
 
         else:
-            self.simulate(test_file['target'], test_file['simulation_technique'], 'no')
+            self.simulate(test_file['target'],
+                          test_file['simulation_technique'], 'no')
 
         # wait
         self.log.info('Wait for 500 seconds before running the detections.')
@@ -85,18 +97,22 @@ class TerraformController(IEnvironmentController):
         result = []
 
         for detection_obj in test_file['detections']:
-            detection_file_name = detection_obj['name'].replace('-','_').replace(' ','_').lower() + '.yml'
-            detection = self.load_file('../security-content/detections/' + detection_file_name)
+            detection_file_name = detection_obj['name'].replace(
+                '-', '_').replace(' ', '_').lower() + '.yml'
+            detection = self.load_file(
+                '../security-content/detections/' + detection_file_name)
             result_obj = dict()
             result_obj['detection'] = detection_obj['name']
-            instance = aws_service.get_instance_by_name("attack-range-splunk-server",self.config)
+            instance = aws_service.get_instance_by_name(
+                self.config['range_name'] + "-attack-range-splunk-server", self.config)
             if instance['State']['Name'] == 'running':
-                result_obj['error'], result_obj['results'] = splunk_sdk.test_search(instance['NetworkInterfaces'][0]['Association']['PublicIp'], str(self.config['splunk_admin_password']), detection['search'], detection_obj['pass_condition'], detection['name'], self.log)
+                result_obj['error'], result_obj['results'] = splunk_sdk.test_search(instance['NetworkInterfaces'][0]['Association']['PublicIp'], str(
+                    self.config['splunk_admin_password']), detection['search'], detection_obj['pass_condition'], detection['name'], self.log)
             else:
                 self.log.error('ERROR: Splunk server is not running.')
             result.append(result_obj)
 
-        #print(result)
+        # print(result)
 
         # store attack data
         if self.config['capture_attack_data'] == '1':
@@ -108,12 +124,13 @@ class TerraformController(IEnvironmentController):
         #result_cond = False
         for result_obj in result:
             if result_obj['error']:
-                self.log.error('Detection Testing failed: ' + result_obj['results']['detection_name'])
+                self.log.error('Detection Testing failed: ' +
+                               result_obj['results']['detection_name'])
                 if self.config['automated_testing'] == '1':
-                    github_service.create_issue(result_obj['results']['detection_name'], self.config)
+                    github_service.create_issue(
+                        result_obj['results']['detection_name'], self.config)
             #result_cond |= result_obj['error']
         sys.exit(0)
-
 
     def load_file(self, file_path):
         with open(file_path, 'r') as stream:
@@ -124,15 +141,15 @@ class TerraformController(IEnvironmentController):
                 sys.exit("ERROR: reading {0}".format(file_path))
         return file
 
-
-
-    def simulate(self, target, simulation_techniques, simulation_atomics, var_str = 'no'):
-        target_public_ip = aws_service.get_single_instance_public_ip(target, self.config)
+    def simulate(self, target, simulation_techniques, simulation_atomics, var_str='no'):
+        target_public_ip = aws_service.get_single_instance_public_ip(
+            target, self.config)
 
         # check if specific atomics are used then it's not allowed to multiple techniques
         techniques_arr = simulation_techniques.split(',')
         if (len(techniques_arr) > 1) and (simulation_atomics != 'no'):
-            self.log.error('ERROR: if simulation_atomics are used, only a single simulation_technique is allowed.')
+            self.log.error(
+                'ERROR: if simulation_atomics are used, only a single simulation_technique is allowed.')
             sys.exit(1)
 
         run_specific_atomic_tests = 'True'
@@ -141,25 +158,30 @@ class TerraformController(IEnvironmentController):
 
         if target == 'attack-range-windows-client':
             runner = ansible_runner.run(private_data_dir='.attack_range/',
-                                   cmdline=str('-i ' + target_public_ip + ', '),
-                                   roles_path="../ansible/roles",
-                                   playbook='../ansible/playbooks/atomic_red_team.yml',
-                                   extravars={'var_str': var_str, 'run_specific_atomic_tests': run_specific_atomic_tests, 'art_run_tests': simulation_atomics, 'art_run_techniques': simulation_techniques, 'ansible_user': 'Administrator', 'ansible_password': self.config['win_password'], 'ansible_port': 5985, 'ansible_winrm_scheme': 'http', 'art_repository': self.config['art_repository'], 'art_branch': self.config['art_branch']},
-                                   verbosity=0)
+                                        cmdline=str(
+                                            '-i ' + target_public_ip + ', '),
+                                        roles_path="../ansible/roles",
+                                        playbook='../ansible/playbooks/atomic_red_team.yml',
+                                        extravars={'var_str': var_str, 'run_specific_atomic_tests': run_specific_atomic_tests, 'art_run_tests': simulation_atomics, 'art_run_techniques': simulation_techniques, 'ansible_user': 'Administrator',
+                                                   'ansible_password': self.config['win_password'], 'ansible_port': 5985, 'ansible_winrm_scheme': 'http', 'art_repository': self.config['art_repository'], 'art_branch': self.config['art_branch']},
+                                        verbosity=0)
         else:
             runner = ansible_runner.run(private_data_dir='.attack_range/',
-                               cmdline=str('-i ' + target_public_ip + ', '),
-                               roles_path="../ansible/roles",
-                               playbook='../ansible/playbooks/atomic_red_team.yml',
-                               extravars={'var_str': var_str, 'run_specific_atomic_tests': run_specific_atomic_tests, 'art_run_tests': simulation_atomics, 'art_run_techniques': simulation_techniques, 'ansible_user': 'Administrator', 'ansible_password': self.config['win_password'], 'art_repository': self.config['art_repository'], 'art_branch': self.config['art_branch']},
-                               verbosity=0)
+                                        cmdline=str(
+                                            '-i ' + target_public_ip + ', '),
+                                        roles_path="../ansible/roles",
+                                        playbook='../ansible/playbooks/atomic_red_team.yml',
+                                        extravars={'var_str': var_str, 'run_specific_atomic_tests': run_specific_atomic_tests, 'art_run_tests': simulation_atomics, 'art_run_techniques': simulation_techniques,
+                                                   'ansible_user': 'Administrator', 'ansible_password': self.config['win_password'], 'art_repository': self.config['art_repository'], 'art_branch': self.config['art_branch']},
+                                        verbosity=0)
 
         if runner.status == "successful":
-            self.log.info("successfully executed technique ID {0} against target: {1}".format(simulation_techniques, target))
+            self.log.info("successfully executed technique ID {0} against target: {1}".format(
+                simulation_techniques, target))
         else:
-            self.log.error("failed to executed technique ID {0} against target: {1}".format(simulation_techniques, target))
+            self.log.error("failed to executed technique ID {0} against target: {1}".format(
+                simulation_techniques, target))
             sys.exit(1)
-
 
     def list_machines(self):
         instances = aws_service.get_all_instances(self.config)
@@ -168,20 +190,22 @@ class TerraformController(IEnvironmentController):
         for instance in instances:
             if instance['State']['Name'] == 'running':
                 instances_running = True
-                response.append([instance['Tags'][0]['Value'], instance['State']['Name'], instance['NetworkInterfaces'][0]['Association']['PublicIp']])
+                response.append([instance['Tags'][0]['Value'], instance['State']['Name'],
+                                 instance['NetworkInterfaces'][0]['Association']['PublicIp']])
             else:
-                response.append([instance['Tags'][0]['Value'], instance['State']['Name']])
+                response.append([instance['Tags'][0]['Value'],
+                                 instance['State']['Name']])
         print()
         print('Status EC2 Machines\n')
         if len(response) > 0:
             if instances_running:
-                print(tabulate(response, headers=['Name','Status', 'IP Address']))
+                print(tabulate(response, headers=[
+                      'Name', 'Status', 'IP Address']))
             else:
-                print(tabulate(response, headers=['Name','Status']))
+                print(tabulate(response, headers=['Name', 'Status']))
         else:
             print("ERROR: Can't find configured EC2 Attack Range Instances in AWS.")
         print()
-
 
     def dump_attack_data(self, dump_name):
 
@@ -204,25 +228,32 @@ class TerraformController(IEnvironmentController):
 
         # dump json and windows event logs from Windows servers
         for server in servers:
-            server_str = ("attack-range-" + server).replace("_","-")
-            target_public_ip = aws_service.get_single_instance_public_ip(server_str, self.config)
+            server_str = ("attack-range-" + server).replace("_", "-")
+            target_public_ip = aws_service.get_single_instance_public_ip(
+                server_str, self.config)
 
             if server_str == 'attack-range-windows-client':
                 runner = ansible_runner.run(private_data_dir='.attack_range/',
-                                       cmdline=str('-i ' + target_public_ip + ', '),
-                                       roles_path="../ansible/roles",
-                                       playbook='../ansible/playbooks/attack_data.yml',
-                                       extravars={'ansible_user': 'Administrator', 'ansible_password': self.config['win_password'], 'ansible_port': 5985, 'ansible_winrm_scheme': 'http', 'hostname': server_str, 'folder': dump_name},
-                                       verbosity=0)
+                                            cmdline=str(
+                                                '-i ' + target_public_ip + ', '),
+                                            roles_path="../ansible/roles",
+                                            playbook='../ansible/playbooks/attack_data.yml',
+                                            extravars={'ansible_user': 'Administrator', 'ansible_password': self.config[
+                                                'win_password'], 'ansible_port': 5985, 'ansible_winrm_scheme': 'http', 'hostname': server_str, 'folder': dump_name},
+                                            verbosity=0)
             else:
                 runner = ansible_runner.run(private_data_dir='.attack_range/',
-                                       cmdline=str('-i ' + target_public_ip + ', '),
-                                       roles_path="../ansible/roles",
-                                       playbook='../ansible/playbooks/attack_data.yml',
-                                       extravars={'ansible_user': 'Administrator', 'ansible_password': self.config['win_password'], 'hostname': server_str, 'folder': dump_name},
-                                       verbosity=0)
+                                            cmdline=str(
+                                                '-i ' + target_public_ip + ', '),
+                                            roles_path="../ansible/roles",
+                                            playbook='../ansible/playbooks/attack_data.yml',
+                                            extravars={
+                                                'ansible_user': 'Administrator', 'ansible_password': self.config['win_password'], 'hostname': server_str, 'folder': dump_name},
+                                            verbosity=0)
 
         if self.config['sync_to_s3_bucket'] == '1':
             for file in glob.glob(folder + "/*"):
-                self.log.info("upload attack data to S3 bucket. This can take some time")
-                aws_service.upload_file_s3_bucket(self.config['s3_bucket_attack_data'], file, str(dump_name + '/' + os.path.basename(file)))
+                self.log.info(
+                    "upload attack data to S3 bucket. This can take some time")
+                aws_service.upload_file_s3_bucket(self.config['s3_bucket_attack_data'], file, str(
+                    dump_name + '/' + os.path.basename(file)))

--- a/terraform/modules/kali_machine/resources.tf
+++ b/terraform/modules/kali_machine/resources.tf
@@ -1,30 +1,30 @@
 
 data "aws_ami" "latest-kali-linux" {
-  count = var.config.kali_machine == "1" ? 1 : 0
+  count       = var.config.kali_machine == "1" ? 1 : 0
   most_recent = true
-  owners = ["679593333241"] # owned by AWS marketplace
+  owners      = ["679593333241"] # owned by AWS marketplace
 
   filter {
-      name   = "name"
-      values = ["Kali Linux 2020*"]
+    name   = "name"
+    values = ["Kali Linux 2020*"]
   }
 
   filter {
-      name   = "virtualization-type"
-      values = ["hvm"]
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }
 
 resource "aws_instance" "kali_machine" {
-  count = var.config.kali_machine == "1" ? 1 : 0
-  ami           = data.aws_ami.latest-kali-linux[count.index].id
-  instance_type = "t2.medium"
-  key_name = var.config.key_name
-  subnet_id = var.ec2_subnet_id
+  count                  = var.config.kali_machine == "1" ? 1 : 0
+  ami                    = data.aws_ami.latest-kali-linux[count.index].id
+  instance_type          = "t2.medium"
+  key_name               = var.config.key_name
+  subnet_id              = var.ec2_subnet_id
   vpc_security_group_ids = [var.vpc_security_group_ids]
-  private_ip = var.config.kali_machine_private_ip
+  private_ip             = var.config.kali_machine_private_ip
   tags = {
-    Name = "attack-range-kali_machine"
+    Name = "${var.config.range_name}-attack-range-kali_machine"
   }
 
   provisioner "remote-exec" {
@@ -41,6 +41,6 @@ resource "aws_instance" "kali_machine" {
 }
 
 resource "aws_eip" "kali_ip" {
-  count = var.config.kali_machine == "1" ? 1 : 0
-  instance      = aws_instance.kali_machine[0].id
+  count    = var.config.kali_machine == "1" ? 1 : 0
+  instance = aws_instance.kali_machine[0].id
 }

--- a/terraform/modules/network/resources.tf
+++ b/terraform/modules/network/resources.tf
@@ -3,25 +3,25 @@
 data "aws_availability_zones" "available" {}
 
 locals {
-  cluster_name = "cluster_${var.config.key_name}"
+  cluster_name = "${var.config.range_name}_cluster_${var.config.key_name}"
 }
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "2.44.0"
 
-  name                 = "vpc_${var.config.key_name}"
+  name                 = "${var.config.range_name}_vpc_${var.config.key_name}"
   cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names
-  public_subnets      = ["10.0.1.0/24"]
+  public_subnets       = ["10.0.1.0/24"]
   enable_dns_hostnames = true
 
 }
 
 
 resource "aws_security_group" "default" {
-  name        = "sg_public_subnets_${var.config.key_name}"
-  vpc_id      = module.vpc.vpc_id
+  name   = "${var.config.range_name}_sg_public_subnets_${var.config.key_name}"
+  vpc_id = module.vpc.vpc_id
 
   ingress {
     from_port   = 0
@@ -31,9 +31,9 @@ resource "aws_security_group" "default" {
   }
 
   egress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    cidr_blocks     = ["0.0.0.0/0"]
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/terraform/modules/phantom-server/resources.tf
+++ b/terraform/modules/phantom-server/resources.tf
@@ -1,37 +1,37 @@
 # install phantom on a fresh centos 7 aws instance
 
 data "aws_ami" "latest-centos" {
-  count         = var.config.phantom_server == "1" ? 1 : 0
+  count       = var.config.phantom_server == "1" ? 1 : 0
   most_recent = true
-  owners = ["679593333241"] # owned by AWS Marketplace
+  owners      = ["679593333241"] # owned by AWS Marketplace
 
   filter {
-      name   = "name"
-      values = ["CentOS Linux 7 x86_64 HVM EBS ENA 1901_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-05713873c6794f575.4"]
+    name   = "name"
+    values = ["CentOS Linux 7 x86_64 HVM EBS ENA 1901_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-05713873c6794f575.4"]
   }
 
   filter {
-      name   = "virtualization-type"
-      values = ["hvm"]
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }
 
 # install Phantom on a bare CentOS 7 instance
 resource "aws_instance" "phantom-server" {
-  count         = var.config.phantom_server == "1" ? 1 : 0
-  ami           = data.aws_ami.latest-centos[count.index].id
-  instance_type = "t3a.xlarge"
-  key_name = var.config.key_name
-  subnet_id = var.ec2_subnet_id
+  count                  = var.config.phantom_server == "1" ? 1 : 0
+  ami                    = data.aws_ami.latest-centos[count.index].id
+  instance_type          = "t3a.xlarge"
+  key_name               = var.config.key_name
+  subnet_id              = var.ec2_subnet_id
   vpc_security_group_ids = [var.vpc_security_group_ids]
-  private_ip = var.config.phantom_server_private_ip
+  private_ip             = var.config.phantom_server_private_ip
   root_block_device {
-    volume_type = "gp2"
-    volume_size = "30"
+    volume_type           = "gp2"
+    volume_size           = "30"
     delete_on_termination = "true"
   }
   tags = {
-    Name = "attack-range-phantom-server"
+    Name = "${var.config.range_name}-attack-range-phantom-server"
   }
 
   provisioner "remote-exec" {
@@ -47,11 +47,11 @@ resource "aws_instance" "phantom-server" {
 
   provisioner "local-exec" {
     working_dir = "../ansible/"
-    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u centos --private-key ${var.config.private_key_path} -i '${aws_instance.phantom-server[0].public_ip},' playbooks/phantom_server.yml -e 'phantom_admin_password=${var.config.phantom_admin_password} phantom_community_username=${var.config.phantom_community_username} phantom_community_password=${var.config.phantom_community_password} phantom_server_private_ip=${var.config.phantom_server_private_ip}'"
+    command     = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u centos --private-key ${var.config.private_key_path} -i '${aws_instance.phantom-server[0].public_ip},' playbooks/phantom_server.yml -e 'phantom_admin_password=${var.config.phantom_admin_password} phantom_community_username=${var.config.phantom_community_username} phantom_community_password=${var.config.phantom_community_password} phantom_server_private_ip=${var.config.phantom_server_private_ip}'"
   }
 }
 
 resource "aws_eip" "phantom_ip" {
-  count         = var.config.phantom_server == "1" ? 1 : 0
+  count    = var.config.phantom_server == "1" ? 1 : 0
   instance = aws_instance.phantom-server[0].id
 }

--- a/terraform/modules/splunk-server/resources.tf
+++ b/terraform/modules/splunk-server/resources.tf
@@ -2,35 +2,35 @@
 
 data "aws_ami" "latest-ubuntu" {
   most_recent = true
-  owners = ["099720109477"] # Canonical
+  owners      = ["099720109477"] # Canonical
 
   filter {
-      name   = "name"
-      values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
   }
 
   filter {
-      name   = "virtualization-type"
-      values = ["hvm"]
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }
 
 
 resource "aws_instance" "splunk-server" {
-  ami           = data.aws_ami.latest-ubuntu.id
-  instance_type = "t2.2xlarge"
-  key_name = var.config.key_name
-  subnet_id = var.ec2_subnet_id
+  ami                    = data.aws_ami.latest-ubuntu.id
+  instance_type          = "t2.2xlarge"
+  key_name               = var.config.key_name
+  subnet_id              = var.ec2_subnet_id
   vpc_security_group_ids = [var.vpc_security_group_ids]
-  private_ip = var.config.splunk_server_private_ip
-  depends_on = [var.phantom_server_instance]
+  private_ip             = var.config.splunk_server_private_ip
+  depends_on             = [var.phantom_server_instance]
   root_block_device {
-    volume_type = "gp2"
-    volume_size = "30"
+    volume_type           = "gp2"
+    volume_size           = "30"
     delete_on_termination = "true"
   }
   tags = {
-    Name = "attack-range-splunk-server"
+    Name = "${var.config.range_name}-attack-range-splunk-server"
   }
 
   provisioner "remote-exec" {
@@ -46,7 +46,7 @@ resource "aws_instance" "splunk-server" {
 
   provisioner "local-exec" {
     working_dir = "../ansible"
-    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u ubuntu --private-key ${var.config.private_key_path} -i '${aws_instance.splunk-server.public_ip},' playbooks/splunk_server.yml -e 'ansible_python_interpreter=/usr/bin/python3 splunk_admin_password=${var.config.splunk_admin_password} splunk_url=${var.config.splunk_url} splunk_binary=${var.config.splunk_binary} s3_bucket_url=${var.config.s3_bucket_url} splunk_escu_app=${var.config.splunk_escu_app} splunk_asx_app=${var.config.splunk_asx_app} splunk_windows_ta=${var.config.splunk_windows_ta} splunk_cim_app=${var.config.splunk_cim_app} splunk_sysmon_ta=${var.config.splunk_sysmon_ta} splunk_python_app=${var.config.splunk_python_app} splunk_mltk_app=${var.config.splunk_mltk_app} caldera_password=${var.config.caldera_password} install_es=${var.config.install_es} splunk_es_app=${var.config.splunk_es_app} phantom_app=${var.config.phantom_app} phantom_server=${var.config.phantom_server} phantom_server_private_ip=${var.config.phantom_server_private_ip} phantom_admin_password=${var.config.phantom_admin_password} splunk_security_essentials_app=${var.config.splunk_security_essentials_app} splunk_bots_dataset=${var.config.splunk_bots_dataset} punchard_custom_visualization=${var.config.punchard_custom_visualization} status_indicator_custom_visualization=${var.config.status_indicator_custom_visualization} splunk_attack_range_dashboard=${var.config.splunk_attack_range_dashboard} timeline_custom_visualization=${var.config.timeline_custom_visualization} splunk_stream_app=${var.config.splunk_stream_app} splunk_server_private_ip=${var.config.splunk_server_private_ip} install_mltk=${var.config.install_mltk}'"
+    command     = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u ubuntu --private-key ${var.config.private_key_path} -i '${aws_instance.splunk-server.public_ip},' playbooks/splunk_server.yml -e 'ansible_python_interpreter=/usr/bin/python3 splunk_admin_password=${var.config.splunk_admin_password} splunk_url=${var.config.splunk_url} splunk_binary=${var.config.splunk_binary} s3_bucket_url=${var.config.s3_bucket_url} splunk_escu_app=${var.config.splunk_escu_app} splunk_asx_app=${var.config.splunk_asx_app} splunk_windows_ta=${var.config.splunk_windows_ta} splunk_cim_app=${var.config.splunk_cim_app} splunk_sysmon_ta=${var.config.splunk_sysmon_ta} splunk_python_app=${var.config.splunk_python_app} splunk_mltk_app=${var.config.splunk_mltk_app} caldera_password=${var.config.caldera_password} install_es=${var.config.install_es} splunk_es_app=${var.config.splunk_es_app} phantom_app=${var.config.phantom_app} phantom_server=${var.config.phantom_server} phantom_server_private_ip=${var.config.phantom_server_private_ip} phantom_admin_password=${var.config.phantom_admin_password} splunk_security_essentials_app=${var.config.splunk_security_essentials_app} splunk_bots_dataset=${var.config.splunk_bots_dataset} punchard_custom_visualization=${var.config.punchard_custom_visualization} status_indicator_custom_visualization=${var.config.status_indicator_custom_visualization} splunk_attack_range_dashboard=${var.config.splunk_attack_range_dashboard} timeline_custom_visualization=${var.config.timeline_custom_visualization} splunk_stream_app=${var.config.splunk_stream_app} splunk_server_private_ip=${var.config.splunk_server_private_ip} install_mltk=${var.config.install_mltk}'"
   }
 }
 

--- a/terraform/modules/windows-client/resources.tf
+++ b/terraform/modules/windows-client/resources.tf
@@ -1,7 +1,7 @@
 
 data "aws_ami" "windows-client-ami" {
-  count = var.config.windows_client == "1" ? 1 : 0
-  owners       = ["self"]
+  count  = var.config.windows_client == "1" ? 1 : 0
+  owners = ["self"]
 
   filter {
     name   = "name"
@@ -13,23 +13,23 @@ data "aws_ami" "windows-client-ami" {
 
 
 resource "aws_instance" "windows_client" {
-  count         = var.config.windows_client == "1" ? 1 : 0
-  ami           = data.aws_ami.windows-client-ami[count.index].id
-  instance_type = "t2.2xlarge"
-  key_name = var.config.key_name
-  subnet_id = var.ec2_subnet_id
+  count                  = var.config.windows_client == "1" ? 1 : 0
+  ami                    = data.aws_ami.windows-client-ami[count.index].id
+  instance_type          = "t2.2xlarge"
+  key_name               = var.config.key_name
+  subnet_id              = var.ec2_subnet_id
   vpc_security_group_ids = [var.vpc_security_group_ids]
-  private_ip = var.config.windows_client_private_ip
-  depends_on = [var.windows_domain_controller_instance]
+  private_ip             = var.config.windows_client_private_ip
+  depends_on             = [var.windows_domain_controller_instance]
   tags = {
-    Name = "attack-range-windows-client"
+    Name = "${var.config.range_name}-attack-range-windows-client"
   }
 
   provisioner "remote-exec" {
     inline = [
       "net user ${var.config.win_username} /active:yes",
       "net user ${var.config.win_username} ${var.config.win_password}"
-      ]
+    ]
 
     connection {
       type     = "winrm"
@@ -46,7 +46,7 @@ resource "aws_instance" "windows_client" {
   provisioner "remote-exec" {
     inline = [
       "net user admin /active:no"
-      ]
+    ]
 
     connection {
       type     = "winrm"
@@ -62,12 +62,12 @@ resource "aws_instance" "windows_client" {
 
   provisioner "local-exec" {
     working_dir = "../ansible"
-    command = "ansible-playbook -i '${aws_instance.windows_client[count.index].public_ip},' playbooks/windows_workstation.yml --extra-vars 'splunk_indexer_ip=${var.config.splunk_server_private_ip} ansible_user=${var.config.win_username} ansible_password=${var.config.win_password} win_password=${var.config.win_password} splunk_uf_win_url=${var.config.splunk_uf_win_url} nxlog_url=${var.config.nxlog_url} win_sysmon_url=${var.config.win_sysmon_url} win_sysmon_template=${var.config.win_sysmon_template} splunk_admin_password=${var.config.splunk_admin_password} windows_domain_controller_private_ip=${var.config.windows_domain_controller_private_ip} windows_server_join_domain=${var.config.windows_client_join_domain} splunk_stream_app=${var.config.splunk_stream_app} s3_bucket_url=${var.config.s3_bucket_url}'"
+    command     = "ansible-playbook -i '${aws_instance.windows_client[count.index].public_ip},' playbooks/windows_workstation.yml --extra-vars 'splunk_indexer_ip=${var.config.splunk_server_private_ip} ansible_user=${var.config.win_username} ansible_password=${var.config.win_password} win_password=${var.config.win_password} splunk_uf_win_url=${var.config.splunk_uf_win_url} nxlog_url=${var.config.nxlog_url} win_sysmon_url=${var.config.win_sysmon_url} win_sysmon_template=${var.config.win_sysmon_template} splunk_admin_password=${var.config.splunk_admin_password} windows_domain_controller_private_ip=${var.config.windows_domain_controller_private_ip} windows_server_join_domain=${var.config.windows_client_join_domain} splunk_stream_app=${var.config.splunk_stream_app} s3_bucket_url=${var.config.s3_bucket_url}'"
   }
 
 }
 
 resource "aws_eip" "windows_client_ip" {
-  count         = var.config.windows_client == "1" ? 1 : 0
+  count    = var.config.windows_client == "1" ? 1 : 0
   instance = aws_instance.windows_client[0].id
 }

--- a/terraform/modules/windows-domain-controller/resources.tf
+++ b/terraform/modules/windows-domain-controller/resources.tf
@@ -1,31 +1,31 @@
 
 data "aws_ami" "latest-windows-server-2016" {
-  count = var.config.windows_domain_controller == "1" ? 1 : 0
+  count       = var.config.windows_domain_controller == "1" ? 1 : 0
   most_recent = true
-  owners = ["801119661308"] # Canonical
+  owners      = ["801119661308"] # Canonical
 
   filter {
-      name   = "name"
-      values = [var.config.windows_domain_controller_os]
+    name   = "name"
+    values = [var.config.windows_domain_controller_os]
   }
 
   filter {
-      name   = "virtualization-type"
-      values = ["hvm"]
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }
 
 
 resource "aws_instance" "windows_domain_controller" {
-  count         = var.config.windows_domain_controller == "1" ? 1 : 0
-  ami           = data.aws_ami.latest-windows-server-2016[count.index].id
-  instance_type = "t2.2xlarge"
-  key_name = var.config.key_name
-  subnet_id = var.ec2_subnet_id
-  private_ip = var.config.windows_domain_controller_private_ip
+  count                  = var.config.windows_domain_controller == "1" ? 1 : 0
+  ami                    = data.aws_ami.latest-windows-server-2016[count.index].id
+  instance_type          = "t2.2xlarge"
+  key_name               = var.config.key_name
+  subnet_id              = var.ec2_subnet_id
+  private_ip             = var.config.windows_domain_controller_private_ip
   vpc_security_group_ids = [var.vpc_security_group_ids]
   tags = {
-    Name = "attack-range-windows-domain-controller"
+    Name = "${var.config.range_name}-attack-range-windows-domain-controller"
   }
   user_data = <<EOF
 <powershell>
@@ -51,12 +51,12 @@ EOF
 
   provisioner "local-exec" {
     working_dir = "../ansible"
-    command = "ansible-playbook -i '${aws_instance.windows_domain_controller[count.index].public_ip},' playbooks/windows_dc.yml --extra-vars 'splunk_indexer_ip=${var.config.splunk_server_private_ip} ansible_user=${var.config.win_username} ansible_password=${var.config.win_password} win_password=${var.config.win_password} splunk_uf_win_url=${var.config.splunk_uf_win_url} nxlog_url=${var.config.nxlog_url} win_sysmon_url=${var.config.win_sysmon_url} win_sysmon_template=${var.config.win_sysmon_template} splunk_admin_password=${var.config.splunk_admin_password} splunk_stream_app=${var.config.splunk_stream_app} s3_bucket_url=${var.config.s3_bucket_url}'"
+    command     = "ansible-playbook -i '${aws_instance.windows_domain_controller[count.index].public_ip},' playbooks/windows_dc.yml --extra-vars 'splunk_indexer_ip=${var.config.splunk_server_private_ip} ansible_user=${var.config.win_username} ansible_password=${var.config.win_password} win_password=${var.config.win_password} splunk_uf_win_url=${var.config.splunk_uf_win_url} nxlog_url=${var.config.nxlog_url} win_sysmon_url=${var.config.win_sysmon_url} win_sysmon_template=${var.config.win_sysmon_template} splunk_admin_password=${var.config.splunk_admin_password} splunk_stream_app=${var.config.splunk_stream_app} s3_bucket_url=${var.config.s3_bucket_url}'"
   }
 
 }
 
 resource "aws_eip" "windows_server_ip" {
-  count         = var.config.windows_domain_controller == "1" ? 1 : 0
+  count    = var.config.windows_domain_controller == "1" ? 1 : 0
   instance = aws_instance.windows_domain_controller[0].id
 }

--- a/terraform/modules/windows-server/resources.tf
+++ b/terraform/modules/windows-server/resources.tf
@@ -1,32 +1,32 @@
 
 data "aws_ami" "latest-windows-server-2016" {
-  count = var.config.windows_server == "1" ? 1 : 0
+  count       = var.config.windows_server == "1" ? 1 : 0
   most_recent = true
-  owners = ["801119661308"] # Canonical
+  owners      = ["801119661308"] # Canonical
 
   filter {
-      name   = "name"
-      values = [var.config.windows_server_os]
+    name   = "name"
+    values = [var.config.windows_server_os]
   }
 
   filter {
-      name   = "virtualization-type"
-      values = ["hvm"]
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }
 
 
 resource "aws_instance" "windows_server" {
-  count         = var.config.windows_server == "1" ? 1 : 0
-  ami           = data.aws_ami.latest-windows-server-2016[count.index].id
-  instance_type = "t2.2xlarge"
-  key_name = var.config.key_name
-  subnet_id = var.ec2_subnet_id
+  count                  = var.config.windows_server == "1" ? 1 : 0
+  ami                    = data.aws_ami.latest-windows-server-2016[count.index].id
+  instance_type          = "t2.2xlarge"
+  key_name               = var.config.key_name
+  subnet_id              = var.ec2_subnet_id
   vpc_security_group_ids = [var.vpc_security_group_ids]
-  private_ip = var.config.windows_server_private_ip
-  depends_on = [var.windows_domain_controller_instance]
+  private_ip             = var.config.windows_server_private_ip
+  depends_on             = [var.windows_domain_controller_instance]
   tags = {
-    Name = "attack-range-windows-server"
+    Name = "${var.config.range_name}-attack-range-windows-server"
   }
   user_data = <<EOF
 <powershell>
@@ -52,12 +52,12 @@ EOF
 
   provisioner "local-exec" {
     working_dir = "../ansible"
-    command = "ansible-playbook -i '${aws_instance.windows_server[count.index].public_ip},' playbooks/windows_dc_client.yml --extra-vars 'splunk_indexer_ip=${var.config.splunk_server_private_ip} ansible_user=${var.config.win_username} ansible_password=${var.config.win_password} win_password=${var.config.win_password} splunk_uf_win_url=${var.config.splunk_uf_win_url} nxlog_url=${var.config.nxlog_url} win_sysmon_url=${var.config.win_sysmon_url} win_sysmon_template=${var.config.win_sysmon_template} splunk_admin_password=${var.config.splunk_admin_password} windows_domain_controller_private_ip=${var.config.windows_domain_controller_private_ip} windows_server_join_domain=${var.config.windows_server_join_domain} splunk_stream_app=${var.config.splunk_stream_app} s3_bucket_url=${var.config.s3_bucket_url}'"
+    command     = "ansible-playbook -i '${aws_instance.windows_server[count.index].public_ip},' playbooks/windows_dc_client.yml --extra-vars 'splunk_indexer_ip=${var.config.splunk_server_private_ip} ansible_user=${var.config.win_username} ansible_password=${var.config.win_password} win_password=${var.config.win_password} splunk_uf_win_url=${var.config.splunk_uf_win_url} nxlog_url=${var.config.nxlog_url} win_sysmon_url=${var.config.win_sysmon_url} win_sysmon_template=${var.config.win_sysmon_template} splunk_admin_password=${var.config.splunk_admin_password} windows_domain_controller_private_ip=${var.config.windows_domain_controller_private_ip} windows_server_join_domain=${var.config.windows_server_join_domain} splunk_stream_app=${var.config.splunk_stream_app} s3_bucket_url=${var.config.s3_bucket_url}'"
   }
 
 }
 
 resource "aws_eip" "windows_server_ip_client" {
-  count         = var.config.windows_server == "1" ? 1 : 0
+  count    = var.config.windows_server == "1" ? 1 : 0
   instance = aws_instance.windows_server[0].id
 }

--- a/terraform/state/state.md
+++ b/terraform/state/state.md
@@ -1,0 +1,1 @@
+This directory contains the state files for multiple deployments.


### PR DESCRIPTION
Added a `range_name` config variable and `-rn` launch variable that will create separate state files in a new `terraform/state` directory.   This allows launching/management of multiple attack ranges for faster dev/demo cycles.  The user can create different environments for different use cases.

Not specifying `-rn` at launch reverts to the default value in the selected config file.