### PR TITLE
ACL for ports

### DIFF
--- a/terraform/modules/network/resources.tf
+++ b/terraform/modules/network/resources.tf
@@ -27,7 +27,28 @@ resource "aws_security_group" "default" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = concat([var.config.ip_whitelist], ["10.0.0.0/16"])
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+ ingress {
+    from_port   = 0
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.config.ip_whitelist]
+  }
+
+ ingress {
+    from_port   = 0
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = [var.config.ip_whitelist]
+  }
+  
+ ingress {
+    from_port   = 0
+    to_port     = 3389
+    protocol    = "-1"
+    cidr_blocks = [var.config.ip_whitelist]
   }
 
   egress {

--- a/terraform/modules/network/resources.tf
+++ b/terraform/modules/network/resources.tf
@@ -47,7 +47,14 @@ resource "aws_security_group" "default" {
  ingress {
     from_port   = 0
     to_port     = 3389
-    protocol    = "-1"
+    protocol    = "tcp"
+    cidr_blocks = [var.config.ip_whitelist]
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 3389
+    protocol    = "udp"
     cidr_blocks = [var.config.ip_whitelist]
   }
 

--- a/terraform/modules/network/resources.tf
+++ b/terraform/modules/network/resources.tf
@@ -31,28 +31,35 @@ resource "aws_security_group" "default" {
   }
 
  ingress {
-    from_port   = 0
+    from_port   = 22
     to_port     = 22
     protocol    = "tcp"
     cidr_blocks = [var.config.ip_whitelist]
   }
 
  ingress {
-    from_port   = 0
+    from_port   = 8000
     to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = [var.config.ip_whitelist]
+  }
+
+   ingress {
+    from_port   = 5986
+    to_port     = 5986
     protocol    = "tcp"
     cidr_blocks = [var.config.ip_whitelist]
   }
   
  ingress {
-    from_port   = 0
+    from_port   = 3389
     to_port     = 3389
     protocol    = "tcp"
     cidr_blocks = [var.config.ip_whitelist]
   }
 
   ingress {
-    from_port   = 0
+    from_port   = 3389
     to_port     = 3389
     protocol    = "udp"
     cidr_blocks = [var.config.ip_whitelist]


### PR DESCRIPTION
These are port rules to only allow ports to control remotely attack_range. This should stop the ddos amplification attacks.