### PR TITLE
Terraform fixes: update ACL and allow ssh-agent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ workflows:
   build-attack-destroy:
     triggers:
       - schedule:
-          cron: "0 10 * * *"
+          cron: "0 11 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ workflows:
   build-attack-destroy:
     triggers:
       - schedule:
-          cron: "0 11 * * *"
+          cron: "30 11 * * *"
           filters:
             branches:
               only:

--- a/README.md
+++ b/README.md
@@ -173,3 +173,5 @@ We welcome feedback and contributions from the community! Please see our [contri
 * Rico Valdez
 * [Dimitris Lambrou](https://twitter.com/etz69)
 * [Dave Herrald](https://twitter.com/daveherrald)
+* Ignacio Bermudez Corrales
+* Peter Gael

--- a/attack_range.conf.template
+++ b/attack_range.conf.template
@@ -25,6 +25,10 @@ ip_whitelist = 0.0.0.0/0
 private_key_path = ~/.ssh/id_rsa
 # Specify the path to your private SSH key
 
+use_ssh_agent = 1
+# Specify whether to load the key directly or via agent (required if encrypted)
+# possible values: 1, 0
+
 region = us-west-2
 # Specify the aws region in which you want to build the attack range
 # please ensure that aws_cli has the same region specified

--- a/attack_range.conf.template
+++ b/attack_range.conf.template
@@ -25,7 +25,7 @@ ip_whitelist = 0.0.0.0/0
 private_key_path = ~/.ssh/id_rsa
 # Specify the path to your private SSH key
 
-use_ssh_agent = 1
+use_ssh_agent = 0
 # Specify whether to load the key directly or via agent (required if encrypted)
 # possible values: 1, 0
 

--- a/terraform/modules/kali_machine/resources.tf
+++ b/terraform/modules/kali_machine/resources.tf
@@ -34,7 +34,9 @@ resource "aws_instance" "kali_machine" {
       type        = "ssh"
       user        = "kali"
       host        = aws_instance.kali_machine[count.index].public_ip
-      private_key = file(var.config.private_key_path)
+      agent       = var.config.use_ssh_agent == "1" ? true : false
+      agent_identity = var.config.use_ssh_agent == "1" ? var.config.private_key_path : null
+      private_key = var.config.use_ssh_agent == "1" ? null : file(var.config.private_key_path)
     }
   }
 

--- a/terraform/modules/network/resources.tf
+++ b/terraform/modules/network/resources.tf
@@ -26,56 +26,63 @@ resource "aws_security_group" "default" {
       from_port   = 0
       to_port     = 0
       protocol    = "-1"
-      cidr_blocks = concat(split(",", var.config.ip_whitelist), ["10.0.0.0/16"])
+      cidr_blocks = ["10.0.0.0/16"]
+    }
+
+   ingress {
+      from_port   = -1
+      to_port     = -1
+      protocol    = "icmp"
+      cidr_blocks = split(",", var.config.ip_whitelist)
     }
 
    ingress {
       from_port   = 22
       to_port     = 22
       protocol    = "tcp"
-      cidr_blocks = concat(split(",", var.config.ip_whitelist), ["10.0.0.0/16"])
+      cidr_blocks = split(",", var.config.ip_whitelist)
     }
 
    ingress {
       from_port   = 8000
       to_port     = 8000
       protocol    = "tcp"
-      cidr_blocks = concat(split(",", var.config.ip_whitelist), ["10.0.0.0/16"])
+      cidr_blocks = split(",", var.config.ip_whitelist)
     }
 
     ingress {
       from_port   = 9997
       to_port     = 9997
       protocol    = "tcp"
-      cidr_blocks = concat(split(",", var.config.ip_whitelist), ["10.0.0.0/16"])
+      cidr_blocks = split(",", var.config.ip_whitelist)
     }
 
     ingress {
       from_port   = 8089
       to_port     = 8089
       protocol    = "tcp"
-      cidr_blocks = concat(split(",", var.config.ip_whitelist), ["10.0.0.0/16"])
+      cidr_blocks = split(",", var.config.ip_whitelist)
     }
 
    ingress {
     from_port   = 5986
     to_port     = 5986
     protocol    = "tcp"
-    cidr_blocks = concat(split(",", var.config.ip_whitelist), ["10.0.0.0/16"])
+    cidr_blocks = split(",", var.config.ip_whitelist)
    }
 
   ingress {
     from_port   = 3389
     to_port     = 3389
     protocol    = "tcp"
-    cidr_blocks = concat(split(",", var.config.ip_whitelist), ["10.0.0.0/16"])
+    cidr_blocks = split(",", var.config.ip_whitelist)
   }
 
   ingress {
     from_port   = 3389
     to_port     = 3389
     protocol    = "udp"
-    cidr_blocks = concat(split(",", var.config.ip_whitelist), ["10.0.0.0/16"])
+    cidr_blocks = split(",", var.config.ip_whitelist)
   }
 
   egress {

--- a/terraform/modules/phantom-server/resources.tf
+++ b/terraform/modules/phantom-server/resources.tf
@@ -41,7 +41,9 @@ resource "aws_instance" "phantom-server" {
       type        = "ssh"
       user        = "centos"
       host        = aws_instance.phantom-server[0].public_ip
-      private_key = file(var.config.private_key_path)
+      agent       = var.config.use_ssh_agent == "1" ? true : false
+      agent_identity = var.config.use_ssh_agent == "1" ? var.config.private_key_path : null
+      private_key = var.config.use_ssh_agent == "1" ? null : file(var.config.private_key_path)
     }
   }
 

--- a/terraform/modules/splunk-server/resources.tf
+++ b/terraform/modules/splunk-server/resources.tf
@@ -40,7 +40,9 @@ resource "aws_instance" "splunk-server" {
       type        = "ssh"
       user        = "ubuntu"
       host        = aws_instance.splunk-server.public_ip
-      private_key = file(var.config.private_key_path)
+      agent       = var.config.use_ssh_agent == "1" ? true : false
+      agent_identity = var.config.use_ssh_agent == "1" ? var.config.private_key_path : null
+      private_key = var.config.use_ssh_agent == "1" ? null : file(var.config.private_key_path)
     }
   }
 


### PR DESCRIPTION
Some minor changes:
1) The previous PR with the network changes still allowed everything from whitelisted CIDRs. This enforces the restriction we discussed
2) I've added a config option `use_ssh_agent` (and added it to the config template 🙃 ). Without the agent's help terraform fails to use ssh keys which are password-protected.