### PR TITLE
Start dump from last simulation's start

### DIFF
--- a/attack_range.py
+++ b/attack_range.py
@@ -28,6 +28,8 @@ def main(args):
                         help="name for the dumped attack data")
     parser.add_argument("--dump", required=False,
                         help="name of the dump as defined in attack_data/dumps.yml")
+    parser.add_argument("--last-sim", required=False, action='store_true',
+                        help="overrides dumps.yml time and dumps from the start of previous simulation")
     parser.add_argument("-c", "--config", required=False, default="attack_range.conf",
                         help="path to the configuration file of the attack range")
     parser.add_argument("-tf", "--test_file", required=False,
@@ -49,6 +51,7 @@ def main(args):
     test_file = args.test_file
     dump_name = args.dump_name
     dump = args.dump
+    last_sim = args.last_sim
 
     print("""
 starting program loaded for B1 battle droid
@@ -141,7 +144,7 @@ starting program loaded for B1 battle droid
         return controller.test(test_file)
 
     if action == 'dump':
-        controller.dump_attack_data(dump_name)
+        controller.dump_attack_data(dump_name, last_sim)
 
     if action == 'replay':
         controller.replay_attack_data(dump_name, dump)

--- a/modules/IEnvironmentController.py
+++ b/modules/IEnvironmentController.py
@@ -38,7 +38,7 @@ class IEnvironmentController(ABC):
         pass
 
     @abstractmethod
-    def dump_attack_data(self, dump_name):
+    def dump_attack_data(self, dump_name, last_sim):
         pass
 
     @abstractmethod

--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -106,8 +106,6 @@ class TerraformController(IEnvironmentController):
                 self.log.error('ERROR: Splunk server is not running.')
             result.append(result_obj)
 
-        # print(result)
-
         # store attack data
         if self.config['capture_attack_data'] == '1':
             self.dump_attack_data(test_file['simulation_technique'])
@@ -132,6 +130,8 @@ class TerraformController(IEnvironmentController):
     def simulate(self, target, simulation_techniques, simulation_atomics, var_str='no'):
         target_public_ip = aws_service.get_single_instance_public_ip(
             target, self.config)
+
+        start_time = time.time()
 
         # check if specific atomics are used then it's not allowed to multiple techniques
         techniques_arr = simulation_techniques.split(',')
@@ -166,10 +166,6 @@ class TerraformController(IEnvironmentController):
             else:
                 stdout_lines = runner.get_fact_cache(target_public_ip)['output_art_var']['stdout_lines']
 
-            # for debug purpose
-            # for line in stdout_lines:
-            #     print(line)
-
             i = 0
             for line in stdout_lines:
                 match = re.search(r'Executing test: (.*)', line)
@@ -185,6 +181,8 @@ class TerraformController(IEnvironmentController):
                         output.append(msg)
                 i += 1
 
+            with open("/tmp/attack-range-%s-last-sim.tmp" % self.config['range_name']) as last_sim:
+                last_sim.write("%s" % start_time)
             return output
         else:
             self.log.error("failed to executed technique ID {0} against target: {1}".format(

--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -255,7 +255,9 @@ class TerraformController(IEnvironmentController):
                             if last_sim:
                                 # if last_sim is set, then it overrides time in dumps.yml
                                 # and starts dumping from last simulation
-                                with open("/tmp/attack-range-%s-last-sim.tmp" % self.config['range_name'], 'r') as ls:
+                                with open(os.path.join(os.path.dirname(__file__),
+                                                       "../attack_data/.%s-last-sim.tmp" % self.config['range_name']),
+                                          'r') as ls:
                                     sim_ts = float(ls.readline())
                                     dump['dump_parameters']['time'] = "-%ds" % int(time.time() - sim_ts)
                             dump_search = "search %s earliest=%s | sort _time" \

--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -181,7 +181,9 @@ class TerraformController(IEnvironmentController):
                         output.append(msg)
                 i += 1
 
-            with open("/tmp/attack-range-%s-last-sim.tmp" % self.config['range_name'], 'w') as last_sim:
+            with open(os.path.join(os.path.dirname(__file__),
+                                   "../attack_data/.%s-last-sim.tmp" % self.config['range_name']),
+                      'w') as last_sim:
                 last_sim.write("%s" % start_time)
             return output
         else:

--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -181,7 +181,7 @@ class TerraformController(IEnvironmentController):
                         output.append(msg)
                 i += 1
 
-            with open("/tmp/attack-range-%s-last-sim.tmp" % self.config['range_name']) as last_sim:
+            with open("/tmp/attack-range-%s-last-sim.tmp" % self.config['range_name'], 'w') as last_sim:
                 last_sim.write("%s" % start_time)
             return output
         else:
@@ -215,7 +215,7 @@ class TerraformController(IEnvironmentController):
             print("ERROR: Can't find configured EC2 Attack Range Instances in AWS.")
         print()
 
-    def dump_attack_data(self, dump_name):
+    def dump_attack_data(self, dump_name, last_sim):
 
         # copy json from nxlog
         # copy raw data using powershell
@@ -252,7 +252,14 @@ class TerraformController(IEnvironmentController):
                     for dump in yaml.full_load(dumps):
                         if dump['enabled']:
                             dump_out = dump['dump_parameters']['out']
-                            dump_search = "search %s earliest=%s | sort _time" % (dump['dump_parameters']['search'], dump['dump_parameters']['time'])
+                            if last_sim:
+                                # if last_sim is set, then it overrides time in dumps.yml
+                                # and starts dumping from last simulation
+                                with open("/tmp/attack-range-%s-last-sim.tmp" % self.config['range_name'], 'r') as ls:
+                                    sim_ts = float(ls.readline())
+                                    dump['dump_parameters']['time'] = "-%ds" % int(time.time() - sim_ts)
+                            dump_search = "search %s earliest=%s | sort _time" \
+                                          % (dump['dump_parameters']['search'], dump['dump_parameters']['time'])
                             dump_info = "Dumping Splunk Search to %s " % dump_out
                             self.log.info(dump_info)
                             out = open(os.path.join(os.path.dirname(__file__), "../attack_data/" + dump_name + "/" + dump_out), 'wb')


### PR DESCRIPTION
Added argument for search dumps to start from last simulation's start. This is helpful for not including events caused by actions such as "build", or any other action performed before the simulation.

```
 python attack_range.py -a dump -dn T1036 --last-sim
```

Without `--last-sim` flag it defaults to time defined in "dumps.yml"