### PR TITLE
Previous commit corrupted dumps

### DIFF
--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -257,7 +257,7 @@ class TerraformController(IEnvironmentController):
                             dump_search = "search %s earliest=%s" % (dump['search'], dump['time'])
                             dump_info = "Dumping Splunk Search to %s " % dump_out
                             self.log.info(dump_info)
-                            out = open(os.path.join(os.path.dirname(__file__), "../attack_data/" + dump_name + "/" + dump_out), 'w')
+                            out = open(os.path.join(os.path.dirname(__file__), "../attack_data/" + dump_name + "/" + dump_out), 'wb')
                             splunk_sdk.export_search(target_public_ip,
                                                      s=dump_search,
                                                      password=self.config['attack_range_password'],

--- a/modules/splunk_sdk.py
+++ b/modules/splunk_sdk.py
@@ -155,5 +155,4 @@ def export_search(host, s, password, export_mode="raw", out=sys.stdout, username
                       data={'output_mode': export_mode,
                             'search': s},
                       verify=False)
-    output = str(r.text.encode('utf-8').strip())
-    out.write(output)
+    out.write(r.text)

--- a/modules/splunk_sdk.py
+++ b/modules/splunk_sdk.py
@@ -155,4 +155,4 @@ def export_search(host, s, password, export_mode="raw", out=sys.stdout, username
                       data={'output_mode': export_mode,
                             'search': s},
                       verify=False)
-    out.write(r.text)
+    out.write(r.text.encode('utf-8'))


### PR DESCRIPTION
Previous commit made dumps not compatible with re-upload. Stripped out all new lines (one single line the whole dump), and added `b'` at the beginning of the dump.