### PR TITLE
Fix missing HTTPS port for Phantom

### DIFF
--- a/terraform/modules/network/resources.tf
+++ b/terraform/modules/network/resources.tf
@@ -85,6 +85,13 @@ resource "aws_security_group" "default" {
     cidr_blocks = split(",", var.config.ip_whitelist)
   }
 
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = split(",", var.config.ip_whitelist)
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
It seems the Phantom HTTPS port (443) is missing from the AWS Security Group.  This should fix it.