### PR TITLE
Add Port for WinRM HTTP

### DIFF
--- a/terraform/modules/network/resources.tf
+++ b/terraform/modules/network/resources.tf
@@ -70,6 +70,13 @@ resource "aws_security_group" "default" {
     protocol    = "tcp"
     cidr_blocks = split(",", var.config.ip_whitelist)
    }
+   
+    ingress {
+    from_port   = 5985
+    to_port     = 5985
+    protocol    = "tcp"
+    cidr_blocks = split(",", var.config.ip_whitelist)
+   }
 
   ingress {
     from_port   = 3389


### PR DESCRIPTION
Adding Port 5985 for WinRM over HTTP which is used for Windows 10 Client