### PR TITLE
dump command bug fix

### DIFF
--- a/ansible/roles/search_head/files/limits.conf
+++ b/ansible/roles/search_head/files/limits.conf
@@ -1,0 +1,2 @@
+[restapi]
+maxresultrows = 4294967295

--- a/ansible/roles/search_head/tasks/configure_limits.yml
+++ b/ansible/roles/search_head/tasks/configure_limits.yml
@@ -1,0 +1,18 @@
+
+- name: Create folder directory for indexes configuration
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: splunk
+    group: splunk
+    recurse: yes
+  with_items:
+    - /opt/splunk/etc/apps/limits_app/local/
+
+- name: copy limits.conf to splunk server
+  copy:
+    src: limits.conf
+    dest: /opt/splunk/etc/apps/limits_app/local/limits.conf
+    owner: splunk
+    group: splunk
+  notify: restart splunk

--- a/ansible/roles/search_head/tasks/main.yml
+++ b/ansible/roles/search_head/tasks/main.yml
@@ -4,6 +4,7 @@
 - include: splunk.yml
 - include: configure_inputs.yml
 - include: configure_indexes.yml
+- include: configure_limits.yml
 - include: configure_web_conf.yml
 - include: configure_server_conf.yml
 - include: configure_props.yml

--- a/attack_data/dumps.yml
+++ b/attack_data/dumps.yml
@@ -2,7 +2,7 @@
   dump_parameters:
     out: windows-sysmon.log
     search: source=XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    time: -2h
+    time: -24h
   replay_parameters:
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
     sourcetype: xmlwineventlog
@@ -13,7 +13,7 @@
   dump_parameters:
     out: windows-security.log
     search: source=WinEventLog:Security
-    time: -2h
+    time: -24h
   replay_parameters:
     source: WinEventLog:Security
     sourcetype: WinEventLog
@@ -24,7 +24,7 @@
   dump_parameters:
     out: windows-system.log
     search: source=WinEventLog:system
-    time: -2h
+    time: -24h
   replay_parameters:
     source: WinEventLog:System
     sourcetype: WinEventLog
@@ -35,7 +35,7 @@
   dump_parameters:
     out: windows-powershell.log
     search: source=WinEventLog:Microsoft-Windows-PowerShell/Operational
-    time: -2h
+    time: -24h
   replay_parameters:
     source: WinEventLog:Microsoft-Windows-PowerShell/Operational
     sourcetype: wineventlog

--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -318,7 +318,7 @@ class TerraformController(IEnvironmentController):
                                           'r') as ls:
                                     sim_ts = float(ls.readline())
                                     dump['dump_parameters']['time'] = "-%ds" % int(time.time() - sim_ts)
-                            dump_search = "search %s earliest=%s | sort _time" \
+                            dump_search = "search %s earliest=%s | sort 0 _time" \
                                           % (dump['dump_parameters']['search'], dump['dump_parameters']['time'])
                             dump_info = "Dumping Splunk Search to %s " % dump_out
                             self.log.info(dump_info)

--- a/modules/splunk_sdk.py
+++ b/modules/splunk_sdk.py
@@ -154,6 +154,7 @@ def export_search(host, s, password, export_mode="raw", out=sys.stdout, username
     r = requests.post("https://%s:%d/servicesNS/admin/search/search/jobs/export" % (host, port),
                       auth=(username, password),
                       data={'output_mode': export_mode,
-                            'search': s},
+                            'search': s,
+                            'max_count': 1000000},
                       verify=False)
     out.write(r.text.encode('utf-8'))


### PR DESCRIPTION
there was a bug in the dump command. The sort command in the dump spl limited the results to 10000 events.