### PR TITLE
updated ps script that gets winrm going

### DIFF
--- a/terraform/aws/modules/windows-client/resources.tf
+++ b/terraform/aws/modules/windows-client/resources.tf
@@ -39,7 +39,7 @@ resource "aws_instance" "windows_client" {
       port     = 5985
       insecure = true
       https    = false
-      timeout  = "7m"
+      timeout  = "10m"
     }
   }
 

--- a/terraform/aws/modules/windows-domain-controller/resources.tf
+++ b/terraform/aws/modules/windows-domain-controller/resources.tf
@@ -31,7 +31,11 @@ resource "aws_instance" "windows_domain_controller" {
 <powershell>
 $admin = [adsi]("WinNT://./Administrator, user")
 $admin.PSBase.Invoke("SetPassword", "${var.config.attack_range_password}")
-Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$Url = 'https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'
+$PSFile = 'C:\ConfigureRemotingForAnsible.ps1'
+Invoke-WebRequest -Uri $Url -OutFile $PSFile
+C:\ConfigureRemotingForAnsible.ps1
 </powershell>
 EOF
 
@@ -46,7 +50,8 @@ EOF
       port     = 5986
       insecure = true
       https    = true
-    }
+      timeout  = "10m"
+	}
   }
 
   provisioner "local-exec" {

--- a/terraform/aws/modules/windows-server/resources.tf
+++ b/terraform/aws/modules/windows-server/resources.tf
@@ -47,6 +47,7 @@ EOF
       port     = 5986
       insecure = true
       https    = true
+      timeout  = "10m"
     }
   }
 

--- a/terraform/aws/modules/windows-server/resources.tf
+++ b/terraform/aws/modules/windows-server/resources.tf
@@ -32,7 +32,11 @@ resource "aws_instance" "windows_server" {
 <powershell>
 $admin = [adsi]("WinNT://./Administrator, user")
 $admin.PSBase.Invoke("SetPassword", "${var.config.attack_range_password}")
-Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$Url = 'https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'
+$PSFile = 'C:\ConfigureRemotingForAnsible.ps1'
+Invoke-WebRequest -Uri $Url -OutFile $PSFile
+C:\ConfigureRemotingForAnsible.ps1
 </powershell>
 EOF
 


### PR DESCRIPTION
Mike Walker, and I were seeing build errors due to connections to the windows host timing out: 
`Error: timeout - last error: unknown error Post "https://34.217.80.191:5986/wsman": dial tcp 34.217.80.191:5986: i/o timeout`

![image](https://user-images.githubusercontent.com/1476868/104532641-adaf9c80-55de-11eb-9713-5e2403444288.png)

after looking at the error closer I though it was due to the default 5 mins for the provisioner not being enough, increased this but still did not solve the issue. After trying to run our current ansible ps script to get winrm going locally, I noticed it was returning an error:
![image](https://user-images.githubusercontent.com/1476868/104532688-d46dd300-55de-11eb-9fc0-8740a5409d52.png)

decided to rewrite and this seemed to have done the trick:
```
$admin = [adsi]("WinNT://./Administrator, user")
$admin.PSBase.Invoke("SetPassword", "${var.config.attack_range_password}")
[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
$Url = 'https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'
$PSFile = 'C:\ConfigureRemotingForAnsible.ps1'
Invoke-WebRequest -Uri $Url -OutFile $PSFile
C:\ConfigureRemotingForAnsible.ps1
```
provisioner is now connecting successfully:

```
module.splunk-server.aws_instance.splunk-server (local-exec): TASK [search_head : download splunk] *******************************************
module.splunk-server.aws_instance.splunk-server: Still creating... [1m20s elapsed]
module.windows-domain-controller.aws_instance.windows_domain_controller[0]: Still creating... [1m20s elapsed]
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec): Connecting to remote host via WinRM...
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec):   Host: 34.222.136.80
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec):   Port: 5986
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec):   User: Administrator
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec):   Password: true
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec):   HTTPS: true
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec):   Insecure: true
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec):   NTLM: false
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec):   CACert: false
module.splunk-server.aws_instance.splunk-server (local-exec): changed: [54.185.14.219]
module.splunk-server.aws_instance.splunk-server (local-exec): TASK [search_head : install splunk binary] *************************************
module.windows-domain-controller.aws_instance.windows_domain_controller[0]: Still creating... [1m30s elapsed]
module.splunk-server.aws_instance.splunk-server: Still creating... [1m30s elapsed]
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec): Connected!
module.splunk-server.aws_instance.splunk-server: Still creating... [1m40s elapsed]
module.windows-domain-controller.aws_instance.windows_domain_controller[0]: Still creating... [1m40s elapsed]
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec): C:\Users\Administrator>echo booted
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (remote-exec): booted
module.windows-domain-controller.aws_instance.windows_domain_controller[0]: Provisioning with 'local-exec'...
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (local-exec): Executing: ["/bin/sh" "-c" "ansible-playbook -i '34.222.136.80,' playbooks/windows_dc.yml --extra-vars 'splunk_indexer_ip=10.0.1.12 ansible_user=Administrator ansible_password=N7MdW46fm6mzKM9Xaa win_password=N7MdW46fm6mzKM9Xaa splunk_uf_win_url=https://download.splunk.com/products/universalforwarder/releases/8.0.2/windows/splunkforwarder-8.0.2-a7f645ddaf91-x64-release.msi win_sysmon_url=https://attack-range-appbinaries.s3-us-west-2.amazonaws.com/Sysmon.zip win_sysmon_template=AttackRangeSysmon.xml splunk_admin_password=N7MdW46fm6mzKM9Xaa splunk_stream_app=splunk-stream_720.tgz s3_bucket_url=https://attack-range-appbinaries.s3-us-west-2.amazonaws.com win_4688_cmd_line=0 verbose_win_security_logging=0'"]
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (local-exec): PLAY [all] *********************************************************************
module.windows-domain-controller.aws_instance.windows_domain_controller[0] (local-exec): TASK [Gathering Facts] *********************************************************
module.windows-domain-controller.aws_instance.windows_domain_controller[0]: Still creating... [1m50s elapsed]
```