### PR TITLE
Add release logic 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,9 +104,18 @@ jobs:
             source venv/bin/activate
             python attack_range.py destroy
           when: on_fail
+  publish-github-release:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - run:
+          name: publish release on github
+          command: |
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG}
+
 workflows:
   version: 2.1
-  build-attack-destroy:
+  nightly-build-attack-destroy:
     triggers:
       - schedule:
           cron: "15 13 * * *"
@@ -116,3 +125,20 @@ workflows:
                 - develop
     jobs:
       - terraform-build-attack-destroy
+  release-build-attack-destroy:
+    jobs:
+      - terraform-build-attack-destroy:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish-github-release:
+        # publish release in github if is a tag
+          requires:
+            - terraform-build-attack-destroy
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Adds a circleCI job and updated workflow to do a full build, then run a simulation T1003.002, then run destroy when a release is tagged. It also makes a github relese using ghr when a tag of vX.X.X is present, where X is a version number.