### PR TITLE
phantom 4.10.1 version upgrade

### DIFF
--- a/ansible/roles/phantom/tasks/install_phantom.yml
+++ b/ansible/roles/phantom/tasks/install_phantom.yml
@@ -21,7 +21,7 @@
 
 - name: install the phantom setup rpm from the community repository
   yum:
-    name: https://repo.phantom.us/phantom/4.10/base/7/x86_64/phantom_repo-4.10.0.40961-1.x86_64.rpm
+    name: https://repo.phantom.us/phantom/4.10/base/7/x86_64/phantom_repo-4.10.1.45070-1.x86_64.rpm
     state: present
 
 # installing apps takes 15+ minutes longer, so later we will install just the apps we need


### PR DESCRIPTION
Phantom had a minor version update, so this keeps attack range on the latest. This should fix build failures with "Error in PREIN scriptlet".