### PR TITLE
Disable Windows Firewall on Domain Clients

### DIFF
--- a/ansible/roles/windows_domain_client/tasks/main.yaml
+++ b/ansible/roles/windows_domain_client/tasks/main.yaml
@@ -3,3 +3,5 @@
 
 - include: create.yml
   when: windows_server_join_domain == "1"
+
+- include: windows-disable-firewall.yml

--- a/ansible/roles/windows_domain_client/tasks/windows-disable-firewall.yml
+++ b/ansible/roles/windows_domain_client/tasks/windows-disable-firewall.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Disable Domain firewall
+  win_firewall:
+    state: disabled
+    profiles:
+    - Domain
+  tags: disable_firewall


### PR DESCRIPTION
This PR adds an extra Ansible task to the **windows_domain_client** role.

The new task, **Disable Domain firewall**, will disable the Windows firewall on the 'Domain' profile on all domain clients. We need this in order to simulate post exploitations attacks such as lateral movement or network share enumeration.

