### PR TITLE
Attack range - Docker support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} attack_range-${CIRCLE_TAG}.tar.gz
   build-docker-image:
     environment:
-      IMAGE_NAME: mvelazco/attack_range
+      IMAGE_NAME: splunkresearch/attack_range
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
@@ -137,6 +137,20 @@ jobs:
       - run:
           name: Build docker image
           command: docker build -t $IMAGE_NAME:latest docker/
+  publish-docker-image:
+    environment: 
+      IMAGE_NAME: splunkresearch/attack_range
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - setup_remote_docker
+      - run:
+          name: Publish Attack Range Docker Image 
+          command: |
+            echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker push $IMAGE_NAME:latest
+
+
       
   
 workflows:
@@ -169,7 +183,11 @@ workflows:
   #            only: /^v.*/
   #          branches:
   #            ignore: /.*/
-  build-docker:
+  build-and-push-docker:
     jobs:
       - build-docker-image
+      - publish-docker-image:
+          requires:
+            - build-docker-image
+
    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,13 +137,27 @@ jobs:
       - run:
           name: Build docker image
           command: docker build -t $IMAGE_NAME:latest docker/
+      - run:
+          name: Archive docker image
+          command: docker save -o attack_range.tar $IMAGE_NAME
+      - persist_to_workspace:
+          root: .
+          paths: 
+            - ./attack_range.tar
+
+
   publish-docker-image:
     environment: 
       IMAGE_NAME: splunkresearch/attack_range
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - setup_remote_docker
+      - run: 
+          name: Load archived image
+          command: docker load -i /tmp/workspace/atttack_range.tar
       - run:
           name: Publish Attack Range Docker Image 
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,36 +169,34 @@ jobs:
   
 workflows:
   version: 2.1
-  #nightly-build-attack-destroy:
-  #  triggers:
-  #    - schedule:
-  #        cron: "15 13 * * *"
-  #        filters:
-  #          branches:
-  #            only:
-  #              - develop
-  #  jobs:
-  #    - terraform-build-attack-destroy
-
-  #release-build-attack-destroy:
-  #  jobs:
-  #    - terraform-build-attack-destroy:
-  #        filters:
-  #          tags:
-  #            only: /^v.*/
-  #          branches:
-  #            ignore: /.*/
-  #    - publish-github-release:
-        # publish release in github if is a tag
-  #        requires:
-  #          - terraform-build-attack-destroy
-  #        filters:
-  #          tags:
-  #            only: /^v.*/
-  #          branches:
-  #            ignore: /.*/
-  build-and-push-docker:
+  nightly-build-attack-destroy:
+    triggers:
+      - schedule:
+          cron: "15 13 * * *"
+          filters:
+            branches:
+              only:
+                - develop
     jobs:
+      - terraform-build-attack-destroy
+
+  release-build-attack-destroy:
+    jobs:
+      - terraform-build-attack-destroy:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish-github-release:
+        # publish release in github if is a tag
+          requires:
+            - terraform-build-attack-destroy
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - build-docker-image
       - publish-docker-image:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,9 +197,19 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-      - build-docker-image
+      - build-docker-image:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - publish-docker-image:
           requires:
             - build-docker-image
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/  
 
    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
   
 workflows:
   version: 2.1
-  nightly-build-attack-destroy:
+  #nightly-build-attack-destroy:
   #  triggers:
   #    - schedule:
   #        cron: "15 13 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
       - setup_remote_docker
       - run: 
           name: Load archived image
-          command: docker load -i /tmp/workspace/atttack_range.tar
+          command: docker load -i /tmp/workspace/attack_range.tar
       - run:
           name: Publish Attack Range Docker Image 
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,8 +135,8 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-        name: Build docker image
-        command: docker build -t $IMAGE_NAME:latest docker/
+          name: Build docker image
+          command: docker build -t $IMAGE_NAME:latest docker/
       
   
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,12 @@ executors:
       - image: circleci/python:latest
     working_directory: ~/repo
 
+  docker-publisher-executor:
+    environment:
+      IMAGE_NAME: splunkresearch/attack_range
+    docker:
+      - image: circleci/buildpack-deps:stretch
+
 jobs:
   terraform-build-attack-destroy:
     executor: content-executor
@@ -127,10 +133,7 @@ jobs:
             tar -zcvf attack_range-${CIRCLE_TAG}.tar.gz attack_range
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} attack_range-${CIRCLE_TAG}.tar.gz
   build-docker-image:
-    environment:
-      IMAGE_NAME: splunkresearch/attack_range
-    docker:
-      - image: circleci/buildpack-deps:stretch
+    executor: docker-publisher-executor
     steps:
       - checkout
       - setup_remote_docker
@@ -147,10 +150,7 @@ jobs:
 
 
   publish-docker-image:
-    environment: 
-      IMAGE_NAME: splunkresearch/attack_range
-    docker:
-      - image: circleci/buildpack-deps:stretch
+    executor: docker-publisher-executor
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,32 +126,50 @@ jobs:
           command: |
             tar -zcvf attack_range-${CIRCLE_TAG}.tar.gz attack_range
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} attack_range-${CIRCLE_TAG}.tar.gz
+  build-docker-image:
+    environment:
+      IMAGE_NAME: mvelazco/attack_range
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+        name: Build docker image
+        command: docker build -t $IMAGE_NAME:latest docker/
+      
+  
 workflows:
   version: 2.1
   nightly-build-attack-destroy:
-    triggers:
-      - schedule:
-          cron: "15 13 * * *"
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - terraform-build-attack-destroy
-  release-build-attack-destroy:
-    jobs:
-      - terraform-build-attack-destroy:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - publish-github-release:
+  #  triggers:
+  #    - schedule:
+  #        cron: "15 13 * * *"
+  #        filters:
+  #          branches:
+  #            only:
+  #              - develop
+  #  jobs:
+  #    - terraform-build-attack-destroy
+
+  #release-build-attack-destroy:
+  #  jobs:
+  #    - terraform-build-attack-destroy:
+  #        filters:
+  #          tags:
+  #            only: /^v.*/
+  #          branches:
+  #            ignore: /.*/
+  #    - publish-github-release:
         # publish release in github if is a tag
-          requires:
-            - terraform-build-attack-destroy
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+  #        requires:
+  #          - terraform-build-attack-destroy
+  #        filters:
+  #          tags:
+  #            only: /^v.*/
+  #          branches:
+  #            ignore: /.*/
+  build-docker:
+    jobs:
+      - build-docker-image
+   

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Attack Range can be built in three different ways:
 
 ## Installation 🏗
 
+### [Using Docker](https://github.com/splunk/attack_range/wiki/Using-Docker)
+
+1. `docker pull splunk/attack_range`
+2. `docker run -it splunk/attack_range`
+
+
 ### [AWS and Ubuntu 18.04](https://github.com/splunk/attack_range/wiki/AWS:-Ubuntu-18.04-Installation)
 
 1. `source <(curl -s 'https://raw.githubusercontent.com/splunk/attack_range/develop/scripts/ubuntu_deploy.sh')`

--- a/README.md
+++ b/README.md
@@ -218,3 +218,4 @@ We welcome feedback and contributions from the community! Please see our [contri
 * Peter Gael
 * Josef Kuepker
 * Shannon Davis
+* [Mauricio Velazco](https://twitter.com/mvelazco)

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Attack Range can be built in three different ways:
 
 ### [Using Docker](https://github.com/splunk/attack_range/wiki/Using-Docker)
 
-1. `docker pull splunk/attack_range`
-2. `docker run -it splunk/attack_range`
+1. `docker pull splunkresearch/attack_range`
+2. `docker run -it splunkresearch/attack_range`
 
 
 ### [AWS and Ubuntu 18.04](https://github.com/splunk/attack_range/wiki/AWS:-Ubuntu-18.04-Installation)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:18.04
+ENV DEBIAN_FRONTEND=noninteractive 
+
+RUN apt-get update && \
+        apt-get install -y python3.8 git unzip python3-pip awscli curl
+
+RUN curl -s https://releases.hashicorp.com/terraform/0.14.4/terraform_0.14.4_linux_amd64.zip -o terraform.zip && \
+         unzip terraform.zip && \
+         mv terraform /usr/local/bin/
+
+RUN git clone https://github.com/splunk/attack_range.git
+RUN echo 'alias python=python3' >> ~/.bashrc
+
+WORKDIR /attack_range
+
+RUN cd terraform/aws && terraform init
+RUN cd terraform/azure && terraform init
+RUN pip3 install -r requirements.txt


### PR DESCRIPTION
This PR introduces docker support for the attack range:

- It adds a Dockerfile under the 'docker' folder.
- It updates the circleci configuration file that builds and pushes a fresh docker image to Docker Hub on every release.

Note: The docker image is currently pushed to splunkresearch/attack_range but will eventually to splunk/attack_range.