### PR TITLE
add sudo to pip3 command

### DIFF
--- a/scripts/ubuntu_deploy.sh
+++ b/scripts/ubuntu_deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 sudo apt-get update
-sudo apt-get install -y python3-dev git unzip python3-pip awscli
-pip3 install virtualenv
+sudo apt-get install -y python3-dev git unzip python3-pip awscli curl
+sudo pip3 install virtualenv
 curl -s https://releases.hashicorp.com/terraform/0.14.4/terraform_0.14.4_linux_amd64.zip -o terraform.zip
 unzip terraform.zip
 sudo mv terraform /usr/local/bin/


### PR DESCRIPTION
adding sudo to the pip command prevents install to .local for run user on ubuntu 20.04

Error below
```
Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

Command 'virtualenv' not found, but can be installed with:

sudo apt install python3-virtualenv

-bash: venv/bin/activate: No such file or directory

Command 'pip' not found, but there are 18 similar ones.
```