### PR TITLE
TR-706 - Update the docker image name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ executors:
 
   docker-publisher-executor:
     environment:
-      IMAGE_NAME: splunkresearch/attack_range
+      IMAGE_NAME: splunk/attack_range
     docker:
       - image: circleci/buildpack-deps:stretch
 


### PR DESCRIPTION
- Renaming the IMAGE_NAME environment variable in the Circle CI config file.
- This will push newly built docker images to https://hub.docker.com/r/splunk/attack_range