### PR TITLE
Add Orca environment support while executing detection test

### DIFF
--- a/attack_range.conf.template
+++ b/attack_range.conf.template
@@ -12,10 +12,11 @@ attack_range_password = Pl3ase-k1Ll-me:p
 # Master password for all administrative accounts
 # default Pl3ase-k1Ll-me:p
 
-cloud_provider = aws
-# cloud provider to deploy the Attack Range
+provider = aws
+# provider to deploy the Attack Range
 # example_1: aws
 # example_2: azure
+# example_3: orca
 
 tf_backend = local
 # Specify terraform backend type 
@@ -34,7 +35,7 @@ tf_backend_name = threat_research_attack_range
 
 [azure]
 azure_subscription_id = xxx
-# only for cloud_provider azure
+# only for provider azure
 # for instructions visit: https://docs.microsoft.com/en-us/azure/media-services/latest/how-to-set-azure-subscription?tabs=portal
 
 instance_type_vms = Standard_D4_v4
@@ -50,6 +51,8 @@ tf_backend_container = tfstate
 # only needed when you specify a remote backend
 
 [orca]
+# only for provider orca
+
 splunk_instance_ip = 127.0.0.1
 # Splunk IP set from orca
 

--- a/attack_range.conf.template
+++ b/attack_range.conf.template
@@ -49,6 +49,16 @@ tf_backend_storage_account = attackrangestorage
 tf_backend_container = tfstate
 # only needed when you specify a remote backend
 
+[orca]
+splunk_instance_ip = 127.0.0.1
+# Splunk IP set from orca
+
+splunk_ssh_port = 2222
+# Splunk ssh port from orca
+
+splunk_rest_port = 8089
+# Splunk rest port from orca
+
 [range_settings]
 key_name = attack-range-key-pair
 # please configure your ssh key name on aws

--- a/attack_range.py
+++ b/attack_range.py
@@ -57,18 +57,18 @@ starting program loaded for B1 battle droid """ + Back.BLACK + Fore.BLUE + Style
     log = logger.setup_logging(config['log_path'], config['log_level'])
     log.info("INIT - attack_range v" + str(VERSION))
 
-    if config['cloud_provider'] == 'azure':
+    if config['provider'] == 'azure':
         os.environ["AZURE_SUBSCRIPTION_ID"] = config['azure_subscription_id']
 
     if config['attack_range_password'] == 'Pl3ase-k1Ll-me:p':
         log.error('ERROR: please change attack_range_password in attack_range.conf')
         sys.exit(1)
 
-    if config['cloud_provider'] == 'azure' and config['zeek_sensor'] == '1':
+    if config['provider'] == 'azure' and config['zeek_sensor'] == '1':
         log.error('ERROR: zeek sensor only available for aws in the moment. Plase change zeek_sensor to 0 and try again.')
         sys.exit(1)
 
-    if config['cloud_provider'] == 'aws' and config['windows_client'] == '1':
+    if config['provider'] == 'aws' and config['windows_client'] == '1':
         log.error('ERROR: windows client is only support for Azure.')
         sys.exit(1)
 

--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -24,9 +24,9 @@ class TerraformController(IEnvironmentController):
     def __init__(self, config, log):
         super().__init__(config, log)
         statefile = self.config['range_name'] + ".terraform.tfstate"
-        if self.config['cloud_provider'] == 'aws':
+        if self.config['provider'] == 'aws':
             self.config["statepath"] = os.path.join(os.path.dirname(__file__), '../terraform/aws/local/state', statefile)
-        elif self.config['cloud_provider'] == 'azure':
+        elif self.config['provider'] == 'azure':
             self.config["statepath"] = os.path.join(os.path.dirname(__file__), '../terraform/azure/local/state', statefile)
 
         self.config['splunk_es_app_version'] = re.findall(r'\d+', self.config['splunk_es_app'])[0]
@@ -36,7 +36,7 @@ class TerraformController(IEnvironmentController):
         variables['config'] = custom_dict
 
         if self.config['tf_backend'] == 'remote':
-            with open(os.path.join(os.path.dirname(__file__), '../terraform', self.config['cloud_provider'], 'remote/resources.tf.j2'), 'r') as file :
+            with open(os.path.join(os.path.dirname(__file__), '../terraform', self.config['provider'], 'remote/resources.tf.j2'), 'r') as file :
                 filedata = file.read()
 
             filedata = filedata.replace('[region]', self.config['region'])
@@ -45,9 +45,9 @@ class TerraformController(IEnvironmentController):
             filedata = filedata.replace('[tf_backend_storage_account]', self.config['tf_backend_storage_account'])
             filedata = filedata.replace('[tf_backend_container]', self.config['tf_backend_container'])
 
-            with open(os.path.join(os.path.dirname(__file__), '../terraform', self.config['cloud_provider'], 'remote/resources.tf'), 'w+') as file:
+            with open(os.path.join(os.path.dirname(__file__), '../terraform', self.config['provider'], 'remote/resources.tf'), 'w+') as file:
                 file.write(filedata)
-        working_dir = os.path.join(os.path.dirname(__file__), '../terraform', self.config['cloud_provider'], self.config['tf_backend'])
+        working_dir = os.path.join(os.path.dirname(__file__), '../terraform', self.config['provider'], self.config['tf_backend'])
 
         self.terraform = Terraform(working_dir=working_dir,variables=variables, parallelism=15 ,state=config.get("statepath"))
 
@@ -55,7 +55,7 @@ class TerraformController(IEnvironmentController):
     def build(self):
         self.log.info("[action] > build\n")
         cwd = os.getcwd()
-        os.system('cd ' + os.path.join(os.path.dirname(__file__), '../terraform', self.config['cloud_provider'], self.config['tf_backend']) + ' && terraform init ')
+        os.system('cd ' + os.path.join(os.path.dirname(__file__), '../terraform', self.config['provider'], self.config['tf_backend']) + ' && terraform init ')
         os.system('cd ' + cwd)
         return_code, stdout, stderr = self.terraform.apply(
             capture_output='yes', skip_plan=True, no_color=IsNotFlagged)
@@ -67,7 +67,7 @@ class TerraformController(IEnvironmentController):
     def destroy(self):
         self.log.info("[action] > destroy\n")
         cwd = os.getcwd()
-        os.system('cd ' + os.path.join(os.path.dirname(__file__), '../terraform', self.config['cloud_provider'], self.config['tf_backend']) + ' && terraform init ')
+        os.system('cd ' + os.path.join(os.path.dirname(__file__), '../terraform', self.config['provider'], self.config['tf_backend']) + ' && terraform init ')
         os.system('cd ' + cwd)
         return_code, stdout, stderr = self.terraform.destroy(
             capture_output='yes', no_color=IsNotFlagged, force=IsNotFlagged, auto_approve=True)
@@ -84,17 +84,17 @@ class TerraformController(IEnvironmentController):
             "attack_range has been destroy using terraform successfully")
 
     def stop(self):
-        if self.config['cloud_provider'] == 'aws':
+        if self.config['provider'] == 'aws':
             instances = aws_service.get_all_instances(self.config)
             aws_service.change_ec2_state(instances, 'stopped', self.log, self.config)
-        elif self.config['cloud_provider'] == 'azure':
+        elif self.config['provider'] == 'azure':
             azure_service.change_instance_state(self.config, 'stopped', self.log)
 
     def resume(self):
-        if self.config['cloud_provider'] == 'aws':
+        if self.config['provider'] == 'aws':
             instances = aws_service.get_all_instances(self.config)
             aws_service.change_ec2_state(instances, 'running', self.log, self.config)
-        elif self.config['cloud_provider'] == 'azure':
+        elif self.config['provider'] == 'azure':
             azure_service.change_instance_state(self.config, 'running', self.log)
 
     def test(self, test_files, test_build_destroy, test_delete_data):
@@ -163,40 +163,40 @@ class TerraformController(IEnvironmentController):
     def get_baseline_result(self, baseline_obj, baseline):
 
         result = {}
-        instance_ip, rest_port = self.get_instance_ip_and_port()
+        instance_ip, splunk_rest_port = self.get_instance_ip_and_port()
 
-        if instance_ip and rest_port:
+        if instance_ip and splunk_rest_port:
             result = splunk_sdk.test_baseline_search(instance_ip, str(self.config['attack_range_password']),
                                                      baseline['search'], baseline_obj['pass_condition'],
                                                      baseline['name'], baseline_obj['file'],
                                                      baseline_obj['earliest_time'], baseline_obj['latest_time'],
-                                                     self.log, rest_port)
+                                                     self.log, splunk_rest_port)
         return result
 
     def get_detection_result(self, detection, test, test_delete_data):
 
         result = {}
-        instance_ip, rest_port = self.get_instance_ip_and_port()
+        instance_ip, splunk_rest_port = self.get_instance_ip_and_port()
 
-        if instance_ip and rest_port:
+        if instance_ip and splunk_rest_port:
             self.log.info("running detection against splunk for indexed data {0}".format(test['file']))
             result = splunk_sdk.test_detection_search(instance_ip, str(self.config['attack_range_password']),
                                                       detection['search'], test['pass_condition'],
                                                       detection['name'], test['file'],
-                                                      test['earliest_time'], test['latest_time'], self.log, rest_port)
+                                                      test['earliest_time'], test['latest_time'], self.log, splunk_rest_port)
 
             if test_delete_data:
                 self.log.info("deleting test data from splunk for test {0}".format(test['file']))
-                splunk_sdk.delete_attack_data(instance_ip, str(self.config['attack_range_password']), rest_port)
+                splunk_sdk.delete_attack_data(instance_ip, str(self.config['attack_range_password']), splunk_rest_port)
 
         return result
 
     def get_instance_ip_and_port(self):
         instance_ip = None
-        rest_port = 8089
+        splunk_rest_port = 8089
 
         # aws cloud provider
-        if self.config['cloud_provider'] == 'aws':
+        if self.config['provider'] == 'aws':
             instance = aws_service.get_instance_by_name('ar-splunk-' + self.config['range_name'] + '-' + self.config['key_name'], self.config)
 
             if instance['State']['Name'] == 'running':
@@ -206,7 +206,7 @@ class TerraformController(IEnvironmentController):
                 return None, None
 
         # azure cloud provider
-        elif self.config['cloud_provider'] == 'azure':
+        elif self.config['provider'] == 'azure':
             instance = azure_service.get_instance(self.config, "ar-splunk-" + self.config['range_name'] + "-" + self.config['key_name'], self.log)
 
             if instance['vm_obj'].instance_view.statuses[1].display_status == "VM running":
@@ -216,11 +216,11 @@ class TerraformController(IEnvironmentController):
                 return None, None
 
         # orca cloud provider
-        elif self.config['cloud_provider'] == 'orca':
+        elif self.config['provider'] == 'orca':
             instance_ip = self.config["splunk_instance_ip"]
-            rest_port = self.config["splunk_rest_port"]
+            splunk_rest_port = self.config["splunk_rest_port"]
 
-        return instance_ip, rest_port
+        return instance_ip, splunk_rest_port
 
     def load_file(self, file_path):
         with open(file_path, 'r', encoding="utf-8") as stream:
@@ -233,11 +233,11 @@ class TerraformController(IEnvironmentController):
 
 
     def simulate(self, target, simulation_techniques, simulation_atomics, var_str='no'):
-        if self.config['cloud_provider'] == 'aws':
+        if self.config['provider'] == 'aws':
             target_public_ip = aws_service.get_single_instance_public_ip(target, self.config)
             ansible_user = 'Administrator'
             ansible_port = 5986
-        elif self.config['cloud_provider'] == 'azure':
+        elif self.config['provider'] == 'azure':
             target_public_ip = azure_service.get_instance(self.config, target, self.log)['public_ip']
             ansible_user = 'AzureAdmin'
             ansible_port = 5985
@@ -356,7 +356,7 @@ class TerraformController(IEnvironmentController):
 
 
     def list_machines(self):
-        if self.config['cloud_provider'] == 'aws':
+        if self.config['provider'] == 'aws':
             instances = aws_service.get_all_instances(self.config)
             response = []
             instances_running = False
@@ -369,7 +369,7 @@ class TerraformController(IEnvironmentController):
                     response.append([instance['Tags'][0]['Value'],
                                      instance['State']['Name']])
 
-        elif self.config['cloud_provider'] == 'azure':
+        elif self.config['provider'] == 'azure':
             instances = azure_service.get_all_instances(self.config)
             response = []
             instances_running = False
@@ -411,6 +411,8 @@ class TerraformController(IEnvironmentController):
     def dump_attack_data(self, dump_name, dump_data):
         self.log.info("Dump log data")
 
+        splunk_rest_port = 8089
+
         folder = "attack_data/" + dump_name
         if os.path.isdir(os.path.join(os.path.dirname(__file__), '../' + folder)):
             self.log.error("folder already. please specify another directory")
@@ -419,14 +421,18 @@ class TerraformController(IEnvironmentController):
             os.mkdir(os.path.join(os.path.dirname(__file__), '../' + folder))
 
         server_str = ("ar-splunk-" + self.config['range_name'] + "-" + self.config['key_name'])
-        if self.config['cloud_provider'] == 'aws':
+        if self.config['provider'] == 'aws':
             target_public_ip = aws_service.get_single_instance_public_ip(server_str, self.config)
             ansible_user = 'Administrator'
             ansible_port = 5986
-        elif self.config['cloud_provider'] == 'azure':
+        elif self.config['provider'] == 'azure':
             target_public_ip = azure_service.get_instance(self.config, server_str, self.log)['public_ip']
             ansible_user = 'AzureAdmin'
             ansible_port = 5985
+        elif self.config['provider'] == 'orca':
+            target_public_ip = self.config["splunk_instance_ip"]
+            splunk_rest_port = self.config['splunk_rest_port']
+
 
 
         dump_search = "search %s earliest=-%s latest=%s | sort 0 _time" \
@@ -437,7 +443,8 @@ class TerraformController(IEnvironmentController):
         splunk_sdk.export_search(target_public_ip,
                                     s=dump_search,
                                     password=self.config['attack_range_password'],
-                                    out=out)
+                                    out=out,
+                                    splunk_rest_port=splunk_rest_port)
         out.close()
         self.log.info("%s [Completed]" % dump_info)
 
@@ -446,11 +453,11 @@ class TerraformController(IEnvironmentController):
         ansible_user = 'ubuntu'
         ansible_port = 22
 
-        if self.config['cloud_provider'] == 'aws':
+        if self.config['provider'] == 'aws':
             splunk_ip = aws_service.get_single_instance_public_ip("ar-splunk-" + self.config['range_name'] + "-" + self.config['key_name'], self.config)
-        elif self.config['cloud_provider'] == 'azure':
+        elif self.config['provider'] == 'azure':
             splunk_ip = azure_service.get_instance(self.config, "ar-splunk-" + self.config['range_name'] + "-" + self.config['key_name'], self.log)['public_ip']
-        elif self.config['cloud_provider'] == 'orca':
+        elif self.config['provider'] == 'orca':
             ansible_user = 'ansible'
             splunk_ip = self.config["splunk_instance_ip"]
             ansible_port = self.config["splunk_ssh_port"]
@@ -481,24 +488,32 @@ class TerraformController(IEnvironmentController):
                                     cmdline=cmdline,
                                     roles_path=os.path.join(os.path.dirname(__file__), '../ansible/roles'),
                                     playbook=os.path.join(os.path.dirname(__file__), '../ansible/playbooks/attack_test.yml'),
-                                    extravars=ansible_vars,)
+                                    extravars=ansible_vars)
 
 
     def update_ESCU_app(self):
+        ansible_user = 'ubuntu'
+        ansible_port = 22
+
         self.log.info("Update ESCU App. This can take some time")
         # upload package
-        if self.config['cloud_provider'] == 'aws':
+        if self.config['provider'] == 'aws':
             splunk_ip = aws_service.get_single_instance_public_ip('ar-splunk-' + self.config['range_name'] + '-' + self.config['key_name'], self.config)
-        elif self.config['cloud_provider'] == 'azure':
+        elif self.config['provider'] == 'azure':
             splunk_ip = azure_service.get_instance(self.config, "ar-splunk-" + self.config['range_name'] + "-" + self.config['key_name'], self.log)['public_ip']
+        elif self.config['provider'] == 'orca':
+            ansible_user = 'ansible'
+            splunk_ip = self.config["splunk_instance_ip"]
+            ansible_port = self.config["splunk_ssh_port"]
         # Upload the replay logs to the Splunk server
         ansible_vars = {}
-        ansible_vars['ansible_user'] = 'ubuntu'
+        ansible_vars['ansible_user'] = ansible_user
         ansible_vars['ansible_ssh_private_key_file'] = self.config['private_key_path']
         ansible_vars['splunk_password'] = self.config['attack_range_password']
         ansible_vars['security_content_path'] = self.config['security_content_path']
+        ansible_vars['ansible_port'] = ansible_port
 
-        cmdline = "-i %s, -u ubuntu" % (splunk_ip)
+        cmdline = "-i %s, -u %s" % (splunk_ip, ansible_user)
         runner = ansible_runner.run(private_data_dir=os.path.join(os.path.dirname(__file__), '../'),
                                     cmdline=cmdline,
                                     roles_path=os.path.join(os.path.dirname(__file__), '../ansible/roles'),
@@ -509,9 +524,15 @@ class TerraformController(IEnvironmentController):
     def execute_savedsearch(self, search_name, earliest, latest):
         self.log.info("Execute savedsearch " + search_name)
 
-        if self.config['cloud_provider'] == 'aws':
-            splunk_ip = aws_service.get_single_instance_public_ip("ar-splunk-" + self.config['range_name'] + "-" + self.config['key_name'], self.config)
-        elif self.config['cloud_provider'] == 'azure':
-            splunk_ip = azure_service.get_instance(self.config, "ar-splunk-" + self.config['range_name'] + "-" + self.config['key_name'], self.log)['public_ip']
+        # Default splunk rest port
+        splunk_rest_port = 8089
 
-        splunk_sdk.execute_savedsearch(splunk_ip, self.config['attack_range_password'], search_name, earliest, latest)
+        if self.config['provider'] == 'aws':
+            splunk_ip = aws_service.get_single_instance_public_ip("ar-splunk-" + self.config['range_name'] + "-" + self.config['key_name'], self.config)
+        elif self.config['provider'] == 'azure':
+            splunk_ip = azure_service.get_instance(self.config, "ar-splunk-" + self.config['range_name'] + "-" + self.config['key_name'], self.log)['public_ip']
+        elif self.config['provider'] == 'orca':
+            splunk_ip = self.config["splunk_instance_ip"]
+            splunk_rest_port = self.config["splunk_rest_port"]
+
+        splunk_sdk.execute_savedsearch(splunk_ip, self.config['attack_range_password'], search_name, earliest, latest, splunk_rest_port=splunk_rest_port)

--- a/modules/configuration.py
+++ b/modules/configuration.py
@@ -163,7 +163,7 @@ starting configuration for AT-ST mech walker
             # get provider
             'type': 'list',
             'message': 'select cloud provider',
-            'name': 'cloud_provider',
+            'name': 'provider',
             'choices': [
                 {
                     'name': 'aws'
@@ -178,7 +178,7 @@ starting configuration for AT-ST mech walker
             'type': 'input',
             'message': 'enter azure subscription id',
             'name': 'azure_subscription_id',
-            'when': lambda answers: answers['cloud_provider'] == 'azure',
+            'when': lambda answers: answers['provider'] == 'azure',
         },
         {
             # get range password
@@ -189,7 +189,7 @@ starting configuration for AT-ST mech walker
         },
     ]
     answers = prompt(questions)
-    if answers['cloud_provider'] == 'aws':
+    if answers['provider'] == 'aws':
         aws_session = boto3.Session()
         if aws_session.region_name:
             aws_configured_region = aws_session.region_name
@@ -198,7 +198,7 @@ starting configuration for AT-ST mech walker
             sys.exit(1)
     else:
         aws_configured_region = ''
-    configuration._sections['global']['cloud_provider'] = answers['cloud_provider']
+    configuration._sections['global']['provider'] = answers['provider']
     configuration._sections['global']['attack_range_password'] = answers['attack_range_password']
     if 'azure_subscription_id' in answers:
         configuration._sections['azure']['azure_subscription_id'] = answers['azure_subscription_id']
@@ -247,14 +247,14 @@ starting configuration for AT-ST mech walker
     if 'new_key_pair' in answers:
         if answers['new_key_pair']:
             # create new ssh key for aws
-            if configuration._sections['global']['cloud_provider'] == "aws":
+            if configuration._sections['global']['provider'] == "aws":
                 new_key_name = create_key_pair_aws(aws_session.client('ec2', region_name=aws_configured_region))
                 new_key_path = Path(new_key_name).resolve()
                 configuration._sections['range_settings']['key_name'] = new_key_name[:-4]
                 configuration._sections['range_settings']['private_key_path'] = str(new_key_path)
                 configuration._sections['range_settings']['public_key_path'] = str(pub_key)
                 print("> new aws ssh created: {}".format(new_key_path))
-            elif configuration._sections['global']['cloud_provider'] == "azure":
+            elif configuration._sections['global']['provider'] == "azure":
                 priv_key_name, pub_key_name = create_key_pair_azure()
                 priv_key_path = Path(priv_key_name).resolve()
                 pub_key_path = Path(pub_key_name).resolve()
@@ -263,7 +263,7 @@ starting configuration for AT-ST mech walker
                 configuration._sections['range_settings']['public_key_path'] = str(pub_key_path)
                 print("> new azure ssh pair created:\nprivate key: {0}\npublic key:{1}".format(priv_key_path, pub_key_path))
             else:
-                print("ERROR, we do not support generating a key pair for the selected provider: {}".format(configuration._sections['global']['cloud_provider']))
+                print("ERROR, we do not support generating a key pair for the selected provider: {}".format(configuration._sections['global']['provider']))
 
 
 

--- a/modules/splunk_sdk.py
+++ b/modules/splunk_sdk.py
@@ -5,11 +5,11 @@ import splunklib.client as client
 import splunklib.results as results
 import requests
 
-def test_baseline_search(splunk_host, splunk_password, search, pass_condition, baseline_name, baseline_file, earliest_time, latest_time, log, rest_port=8089):
+def test_baseline_search(splunk_host, splunk_password, search, pass_condition, baseline_name, baseline_file, earliest_time, latest_time, log, splunk_rest_port=8089):
     try:
         service = client.connect(
             host=splunk_host,
-            port=rest_port,
+            port=splunk_rest_port,
             username='admin',
             password=splunk_password
         )
@@ -62,11 +62,11 @@ def test_baseline_search(splunk_host, splunk_password, search, pass_condition, b
         return test_results
 
 
-def test_detection_search(splunk_host, splunk_password, search, pass_condition, detection_name, detection_file, earliest_time, latest_time, log, rest_port=8089):
+def test_detection_search(splunk_host, splunk_password, search, pass_condition, detection_name, detection_file, earliest_time, latest_time, log, splunk_rest_port=8089):
     try:
         service = client.connect(
             host=splunk_host,
-            port=rest_port,
+            port=splunk_rest_port,
             username='admin',
             password=splunk_password
         )
@@ -119,12 +119,12 @@ def test_detection_search(splunk_host, splunk_password, search, pass_condition, 
         return test_results
 
 
-def search(splunk_host, splunk_password, search_name, log):
+def search(splunk_host, splunk_password, search_name, log, splunk_rest_port=8089):
     print('\nexecute savedsearch: ' + search_name + '\n')
 
     service = client.connect(
         host=splunk_host,
-        port=8089,
+        port=splunk_rest_port,
         username='admin',
         password=splunk_password
     )
@@ -172,10 +172,10 @@ def search(splunk_host, splunk_password, search_name, log):
     mysavedsearch.update(**kwargs).refresh()
 
 
-def list_searches(splunk_host, splunk_password):
+def list_searches(splunk_host, splunk_password, splunk_rest_port=8089):
     service = client.connect(
         host=splunk_host,
-        port=8089,
+        port=splunk_rest_port,
         username='admin',
         password=splunk_password
     )
@@ -201,7 +201,7 @@ def test():
     print(return_value)
 
 
-def export_search(host, s, password, export_mode="raw", out=sys.stdout, username="admin", port=8089):
+def export_search(host, s, password, export_mode="raw", out=sys.stdout, username="admin", splunk_rest_port=8089):
     """
     Exports events from a search using Splunk REST API to a local file.
 
@@ -217,7 +217,7 @@ def export_search(host, s, password, export_mode="raw", out=sys.stdout, username
     """
     import urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    r = requests.post("https://%s:%d/servicesNS/admin/search/search/jobs/export" % (host, port),
+    r = requests.post("https://%s:%d/servicesNS/admin/search/search/jobs/export" % (host, splunk_rest_port),
                       auth=(username, password),
                       data={'output_mode': export_mode,
                             'search': s,
@@ -227,11 +227,11 @@ def export_search(host, s, password, export_mode="raw", out=sys.stdout, username
 
 
 
-def delete_attack_data(splunk_host, splunk_password, splunk_mgmt_port=8089):
+def delete_attack_data(splunk_host, splunk_password, splunk_rest_port=8089):
     try:
         service = client.connect(
             host=splunk_host,
-            port=splunk_mgmt_port,
+            port=splunk_rest_port,
             username='admin',
             password=splunk_password
         )
@@ -254,11 +254,11 @@ def delete_attack_data(splunk_host, splunk_password, splunk_mgmt_port=8089):
     return True
 
 
-def execute_savedsearch(splunk_host, splunk_password, search_name, earliest, latest):
+def execute_savedsearch(splunk_host, splunk_password, search_name, earliest, latest, splunk_rest_port=8089):
     try:
         service = client.connect(
             host=splunk_host,
-            port=8089,
+            port=splunk_rest_port,
             username='admin',
             password=splunk_password,
             app="dev_sec_ops_analytics"

--- a/modules/splunk_sdk.py
+++ b/modules/splunk_sdk.py
@@ -5,17 +5,17 @@ import splunklib.client as client
 import splunklib.results as results
 import requests
 
-def test_baseline_search(splunk_host, splunk_password, search, pass_condition, baseline_name, baseline_file, earliest_time, latest_time, log):
+def test_baseline_search(splunk_host, splunk_password, search, pass_condition, baseline_name, baseline_file, earliest_time, latest_time, log, rest_port=8089):
     try:
         service = client.connect(
             host=splunk_host,
-            port=8089,
+            port=rest_port,
             username='admin',
             password=splunk_password
         )
     except Exception as e:
         log.error("Unable to connect to Splunk instance: " + str(e))
-        return 1, {}
+        return {}
 
     # search and replace \\ with \\\
     # search = search.replace('\\','\\\\')
@@ -35,14 +35,22 @@ def test_baseline_search(splunk_host, splunk_password, search, pass_condition, b
         job = service.jobs.create(splunk_search, **kwargs)
     except Exception as e:
         log.error("Unable to execute baseline: " + str(e))
-        return 1, {}
+        return {}
 
-    test_results = dict()
-    test_results['diskUsage'] = job['diskUsage']
-    test_results['runDuration'] = job['runDuration']
-    test_results['baseline_name'] = baseline_name
-    test_results['baseline_file'] = baseline_file
-    test_results['scanCount'] = job['scanCount']
+    try:
+        test_results = dict()
+        test_results['diskUsage'] = job['diskUsage']
+        test_results['runDuration'] = job['runDuration']
+        test_results['baseline_name'] = baseline_name
+        test_results['baseline_file'] = baseline_file
+        test_results['scanCount'] = job['scanCount']
+        test_results["splunk_search"] = splunk_search
+        test_results["resultCount"] = job['resultCount']
+        test_results["messages"] = job["messages"]
+
+    except Exception as exc:
+        log.error(f"Caught an exception during updating test_results in test_baseline_search, exception: {exc}")
+
 
     if int(job['resultCount']) != 1:
         log.error("Test failed for baseline: " + baseline_name)
@@ -54,17 +62,17 @@ def test_baseline_search(splunk_host, splunk_password, search, pass_condition, b
         return test_results
 
 
-def test_detection_search(splunk_host, splunk_password, search, pass_condition, detection_name, detection_file, earliest_time, latest_time, log):
+def test_detection_search(splunk_host, splunk_password, search, pass_condition, detection_name, detection_file, earliest_time, latest_time, log, rest_port=8089):
     try:
         service = client.connect(
             host=splunk_host,
-            port=8089,
+            port=rest_port,
             username='admin',
             password=splunk_password
         )
     except Exception as e:
         log.error("Unable to connect to Splunk instance: " + str(e))
-        return 1, {}
+        return {}
 
     # search and replace \\ with \\\
     # search = search.replace('\\','\\\\')
@@ -84,14 +92,22 @@ def test_detection_search(splunk_host, splunk_password, search, pass_condition, 
         job = service.jobs.create(splunk_search, **kwargs)
     except Exception as e:
         log.error("Unable to execute detection: " + str(e))
-        return 1, {}
+        return {}
 
-    test_results = dict()
-    test_results['diskUsage'] = job['diskUsage']
-    test_results['runDuration'] = job['runDuration']
-    test_results['detection_name'] = detection_name
-    test_results['detection_file'] = detection_file
-    test_results['scanCount'] = job['scanCount']
+    try:
+        test_results = dict()
+        test_results['diskUsage'] = job['diskUsage']
+        test_results['runDuration'] = job['runDuration']
+        test_results['detection_name'] = detection_name
+        test_results['detection_file'] = detection_file
+        test_results['scanCount'] = job['scanCount']
+        test_results["splunk_search"] = splunk_search
+        test_results["resultCount"] = job['resultCount']
+        test_results["messages"] = job["messages"]
+
+    except Exception as exc:
+        log.error(f"Caught an exception during updating test_results in test_detection_search, exception: {exc}")
+
 
     if int(job['resultCount']) != 1:
         log.error("test failed for detection: " + detection_name)
@@ -211,11 +227,11 @@ def export_search(host, s, password, export_mode="raw", out=sys.stdout, username
 
 
 
-def delete_attack_data(splunk_host, splunk_password):
+def delete_attack_data(splunk_host, splunk_password, splunk_mgmt_port=8089):
     try:
         service = client.connect(
             host=splunk_host,
-            port=8089,
+            port=splunk_mgmt_port,
             username='admin',
             password=splunk_password
         )


### PR DESCRIPTION
Added support to the orca environment while executing detection tests. Ensuring changes has been introduced in this PR:

- `attack_range.conf.template` : added stanza for Splunk instance configuration spin up by orca
- `modules/TerraformController.py` : Break down detection test in following methods
   - `get_baseline_result(baseline_obj, baseline)` : To get baseline search result from splunk instance
   - `get_detection_result(detection, test, test_delete_data)`: To get detection search result from splunk instance
   - `get_instance_ip_and_port(self)` : Get splunk instance ip and rest port
   - make ansible user and port configurable 
- `modules/splunk_sdk.py`
  - make ansible user and port configurable 
  - enrich detection test dictionary  by adding splunk_search, result count and message in test response