### PR TITLE
osquery_fix_pack_path

### DIFF
--- a/ansible/roles/osquery_linux/files/template.osquery.conf
+++ b/ansible/roles/osquery_linux/files/template.osquery.conf
@@ -71,16 +71,28 @@
   // OS X:         /var/osquery/packs
   // Homebrew:     /usr/local/share/osquery/packs
   // make install: {PREFIX}/share/osquery/packs
-  //
-  "packs": {
-     "osquery-monitoring": "/usr/share/osquery/packs/osquery-monitoring.conf",
-     "incident-response": "/usr/share/osquery/packs/incident-response.conf",
-     "it-compliance": "/usr/share/osquery/packs/it-compliance.conf",
-    // "osx-attacks": "/usr/share/osquery/packs/osx-attacks.conf",
-     "vuln-management": "/usr/share/osquery/packs/vuln-management.conf",
-     "hardware-monitoring": "/usr/share/osquery/packs/hardware-monitoring.conf",
-     "ossec-rootkit": "/usr/share/osquery/packs/ossec-rootkit.conf",
-     "attack-range": "/usr/share/osquery/packs/attack-range.conf"
+  // new pack folder path: /opt/osquery/share/osquery/packs
+  //"packs": {
+  //   "osquery-monitoring": "/usr/share/osquery/packs/osquery-monitoring.conf",
+  //   "incident-response": "/usr/share/osquery/packs/incident-response.conf",
+  //   "it-compliance": "/usr/share/osquery/packs/it-compliance.conf",
+  //  // "osx-attacks": "/usr/share/osquery/packs/osx-attacks.conf",
+  //   "vuln-management": "/usr/share/osquery/packs/vuln-management.conf",
+  //   "hardware-monitoring": "/usr/share/osquery/packs/hardware-monitoring.conf",
+  //   "ossec-rootkit": "/usr/share/osquery/packs/ossec-rootkit.conf",
+  //   "attack-range": "/usr/share/osquery/packs/attack-range.conf"
+  //  // "windows-hardening": "C:\\Program Files\\osquery\\packs\\windows-hardening.conf",
+  //  // "windows-attacks": "C:\\Program Files\\osquery\\packs\\windows-attacks.conf"
+  //}
+   "packs": {
+     "osquery-monitoring": "/opt/osquery/share/osquery/packs/osquery-monitoring.conf",
+     "incident-response": "/opt/osquery/share/osquery/packs/incident-response.conf",
+     "it-compliance": "/opt/osquery/share/osquery/packs/it-compliance.conf",
+    // "osx-attacks": "/opt/osquery/share/osquery/packs/osx-attacks.conf",
+     "vuln-management": "/opt/osquery/share/osquery/packs/vuln-management.conf",
+     "hardware-monitoring": "/opt/osquery/share/osquery/packs/hardware-monitoring.conf",
+     "ossec-rootkit": "/opt/osquery/share/osquery/packs/ossec-rootkit.conf",
+     "attack-range": "/opt/osquery/share/osquery/packs/attack-range.conf"
     // "windows-hardening": "C:\\Program Files\\osquery\\packs\\windows-hardening.conf",
     // "windows-attacks": "C:\\Program Files\\osquery\\packs\\windows-attacks.conf"
   },

--- a/ansible/roles/osquery_linux/tasks/install_osquery_linux.yml
+++ b/ansible/roles/osquery_linux/tasks/install_osquery_linux.yml
@@ -33,11 +33,17 @@
     src: template.osquery.conf
     dest: /etc/osquery/osquery.conf 
 
-- name: copy custom osquery conf template as /usr/share/osquery/packs/attack-range.conf
+- name: copy template.osquery.conf /var/osquery/osquery.conf
+  become: true
+  copy:
+    src: template.osquery.conf
+    dest: /var/osquery/osquery.conf 
+
+- name: copy custom osquery conf template as /opt/osquery/share/osquery/packs/attack-range.conf
   become: true
   copy: 
     src: "{{ custom_osquery_conf }}" 
-    dest: /usr/share/osquery/packs/attack-range.conf
+    dest: /opt/osquery/share/osquery/packs/attack-range.conf
 
 - name: activate osqueryd service
   become: true


### PR DESCRIPTION
## scenario:
encounter some build break while building osquery AR instance.

```
Error: Error running command 'ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u ubuntu --private-key ~/.ssh/id_rsa -i '3.67.11.215,' playbooks/osquery_machine.yml -e 'splunk_indexer_ip=10.0.1.12 splunk_uf_url=https://download.splunk.com/products/universalforwarder/releases/8.2.2.1/linux/splunkforwarder-8.2.2.1-ae6821b7c64b-linux-2.6-amd64.deb custom_osquery_conf=custom_osquery.conf'': exit status 2. Output:
```

## root cause:
osquery installation path for its configuration was updated in both osquery.conf and rules configuration.

## fix:
 fix and update those path in ansible script and for the osquery.conf.

![Screenshot 2021-11-10 at 11 23 28](https://user-images.githubusercontent.com/26181693/141106154-a193cd31-c3db-4f1c-910a-734b565c109c.png)


