### PR TITLE
Update powershell_inputs.conf

### DIFF
--- a/ansible/roles/windows_universal_forwarder/files/powershell_inputs.conf
+++ b/ansible/roles/windows_universal_forwarder/files/powershell_inputs.conf
@@ -1,3 +1,5 @@
 [WinEventLog://Microsoft-Windows-PowerShell/Operational]
-disabled = false
-index = win
+disabled = 0
+renderXml = 1
+source = XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
+sourcetype = XmlWinEventLog


### PR DESCRIPTION
Converting PowerShell logs to XML by default in Attack Range.

Related to https://github.com/splunk/security_content/issues/2039