### PR TITLE
ingest data in the custom index

### DIFF
--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -150,7 +150,6 @@ class TerraformController(IEnvironmentController):
                     else:
                         attack_data['update_timestamp'] = False
                     #attack_data['update_timestamp'] = True
-                    attack_data['index'] = 'test'
                     self.replay_attack_data(dump_name, attack_data)
 
                 # wait for indexing
@@ -214,8 +213,11 @@ class TerraformController(IEnvironmentController):
                                                       test['earliest_time'], test['latest_time'], self.log, splunk_rest_port)
 
             if test_delete_data:
+                indexes = set()
+                for attack_data in test.get('attack_data'):
+                    indexes.add(attack_data.get('custom_index', 'test'))
                 self.log.info("deleting test data from splunk for test {0}".format(test['file']))
-                splunk_sdk.delete_attack_data(instance_ip, str(self.config['attack_range_password']), splunk_rest_port)
+                splunk_sdk.delete_attack_data(instance_ip, str(self.config['attack_range_password']), splunk_rest_port, list(indexes))
 
         return result
 
@@ -618,7 +620,7 @@ class TerraformController(IEnvironmentController):
         ansible_vars['out'] = attack_data['file_name']
         ansible_vars['sourcetype'] = attack_data['sourcetype']
         ansible_vars['source'] = attack_data['source']
-        ansible_vars['index'] = attack_data['index']
+        ansible_vars['index'] = attack_data.get('custom_index', 'test')
         ansible_vars['update_timestamp'] = attack_data['update_timestamp']
 
         if 'data' in attack_data:

--- a/modules/splunk_sdk.py
+++ b/modules/splunk_sdk.py
@@ -250,7 +250,7 @@ def export_search(host, s, password, export_mode="raw", out=sys.stdout, username
 
 
 
-def delete_attack_data(splunk_host, splunk_password, splunk_rest_port=8089):
+def delete_attack_data(splunk_host, splunk_password, splunk_rest_port=8089, indexes=['test']):
     """
     delete_attack_data function creates a delete job on the splunk server.
 
@@ -268,18 +268,19 @@ def delete_attack_data(splunk_host, splunk_password, splunk_rest_port=8089):
     except Exception as e:
         print("Unable to connect to Splunk instance: " + str(e))
         return False
+    
+    for index in indexes:
+        splunk_search = f'search index={index}* | delete'
 
-    splunk_search = 'search index=test* | delete'
+        kwargs = {"exec_mode": "blocking",
+                "dispatch.earliest_time": "-1d",
+                "dispatch.latest_time": "now"}
 
-    kwargs = {"exec_mode": "blocking",
-              "dispatch.earliest_time": "-1d",
-              "dispatch.latest_time": "now"}
-
-    try:
-        job = service.jobs.create(splunk_search, **kwargs)
-    except Exception as e:
-        print("Unable to execute search: " + str(e))
-        return False
+        try:
+            job = service.jobs.create(splunk_search, **kwargs)
+        except Exception as e:
+            print("Unable to execute search: " + str(e))
+            return False
 
     return True
 


### PR DESCRIPTION
- Replay the attack_data in the custom index mentioned in the [security_content](https://github.com/splunk/security_content) test file. It will ingest the attack_data if detections don't require any custom index.
- Instead of deleting the data from a specific index, now we can delete the data from the list of indexes.