### PR TITLE
Changing default windows event logs to XML

### DIFF
--- a/ansible/roles/windows_universal_forwarder/tasks/collect_windows_event_logs.yml
+++ b/ansible/roles/windows_universal_forwarder/tasks/collect_windows_event_logs.yml
@@ -7,5 +7,5 @@
 
 - name: Copy inputs.conf configuration
   win_copy:
-    src: win_event_log_inputs_plain.conf
+    src: win_event_log_inputs.conf
     dest: 'C:\Program Files\SplunkUniversalForwarder\etc\apps\win_inputs_app\local\inputs.conf'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible==5.6.0
-ansible-core==2.12.4
-ansible-runner==2.1.3
+ansible==6.3.0
+ansible-core==2.13.3
+ansible-runner==2.2.1
 apipkg==2.1.0
 aspy.yaml==1.3.0
 atomicwrites==1.4.0


### PR DESCRIPTION
Within `ansible/roles/windows_universal_forwarder/tasks/collect_windows_event_logs.yml`, changing `win_event_log_inputs_plain.conf` to `win_event_log_inputs.conf`. This will change the default output for Windows logs to XML.