### PR TITLE
Manually installing nginx on ubuntu 18.04

### DIFF
--- a/ansible/playbooks/nginx_web_proxy.yml
+++ b/ansible/playbooks/nginx_web_proxy.yml
@@ -2,4 +2,5 @@
   gather_facts: False
   become: true
   roles:
+    - linux_common
     - nginx_web_proxy

--- a/ansible/playbooks/nginx_web_proxy.yml
+++ b/ansible/playbooks/nginx_web_proxy.yml
@@ -1,6 +1,8 @@
 - hosts: all
   gather_facts: False
   become: true
+  vars:  
+    hostname: nginx
   roles:
     - linux_common
     - nginx_web_proxy

--- a/ansible/roles/nginx_web_proxy/files/nginx.conf
+++ b/ansible/roles/nginx_web_proxy/files/nginx.conf
@@ -14,10 +14,6 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-#    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-#                      '$status $body_bytes_sent "$http_referer" '
-#                      '"$http_user_agent" "$http_x_forwarded_for"';
-
     log_format kv 'site="$server_name" server="$host" dest_port="$server_port" dest_ip="$server_addr" '
                        'src="$remote_addr" src_ip="$realip_remote_addr" user="$remote_user" '
                        'time_local="$time_local" protocol="$server_protocol" status="$status" '
@@ -32,30 +28,9 @@ http {
     access_log  /var/log/nginx/access.log  kv;
 
     sendfile        on;
-    #tcp_nopush     on;
 
     keepalive_timeout  65;
 
-    #gzip  on;
 
     include /etc/nginx/conf.d/*.conf;
 }
-
-
-# TCP/UDP proxy and load balancing block
-#
-#stream {
-    # Example configuration for TCP load balancing
-
-    #upstream stream_backend {
-    #    zone tcp_servers 64k;
-    #    server backend1.example.com:12345;
-    #    server backend2.example.com:12345;
-    #}
-
-    #server {
-    #    listen 12345;
-    #    status_zone tcp_server;
-    #    proxy_pass stream_backend;
-    #}
-#}

--- a/ansible/roles/nginx_web_proxy/tasks/main.yml
+++ b/ansible/roles/nginx_web_proxy/tasks/main.yml
@@ -8,3 +8,7 @@
 - name: restart splunk
   become: true
   command: "/opt/splunkforwarder/bin/splunk restart"
+
+- name: restart nginx again
+  become: true
+  command: "nginx -s reload"

--- a/ansible/roles/nginx_web_proxy/tasks/nginx_web_proxy.yml
+++ b/ansible/roles/nginx_web_proxy/tasks/nginx_web_proxy.yml
@@ -1,4 +1,10 @@
 ---
+- name: install nginx
+  apt:
+    name:  nginx 
+    state: latest
+    update_cache: yes
+    
 - name: copy nginx.conf to add kv logging to nginx plus
   copy:
     src: nginx.conf

--- a/ansible/roles/nginx_web_proxy/tasks/nginx_web_proxy.yml
+++ b/ansible/roles/nginx_web_proxy/tasks/nginx_web_proxy.yml
@@ -5,6 +5,12 @@
     state: latest
     update_cache: yes
     
+- name: add nginx user
+  ansible.builtin.user:
+    name: nginx
+    shell: /bin/false
+    create_home: no 
+
 - name: copy nginx.conf to add kv logging to nginx plus
   copy:
     src: nginx.conf
@@ -15,7 +21,3 @@
     src: default.conf.j2
     dest: /etc/nginx/conf.d/default.conf
 
-- name: reload nginx
-  systemd:
-    daemon_reload: yes
-    name: nginx

--- a/ansible/roles/nginx_web_proxy/templates/default.conf.j2
+++ b/ansible/roles/nginx_web_proxy/templates/default.conf.j2
@@ -7,7 +7,7 @@ server {
     location / {
     #    root   /usr/share/nginx/html;
     #    index  index.html index.htm;
-        proxy_pass   http://{nginx_web_proxy_host}}:{{nginx_web_proxy_port}};
+         proxy_pass   http://{{nginx_web_proxy_host}}:{{nginx_web_proxy_port}};
     }
 
     #error_page  404              /404.html;

--- a/attack_range.conf.template
+++ b/attack_range.conf.template
@@ -493,7 +493,7 @@ nginx_web_proxy_private_ip = 10.0.1.21
 nginx_web_proxy_host = 10.0.1.20
 # what machine to proxy web traffic to, defaults to sysmon_linux_private_ip
 
-nginx_web_proxy_port = 8000
+nginx_web_proxy_port = 8080
 # what port to proxy web traffic to, defaults to 8080
 
 [aurora_agent]

--- a/attack_range.conf.template
+++ b/attack_range.conf.template
@@ -490,7 +490,7 @@ nginx_web_proxy_private_ip = 10.0.1.21
 # specify the nginx_web_proxy machine private ip
 # should be in subnet: 10.0.1.0/24
 
-nginx_web_proxy_host = 10.0.1.12
+nginx_web_proxy_host = 10.0.1.20
 # what machine to proxy web traffic to, defaults to sysmon_linux_private_ip
 
 nginx_web_proxy_port = 8000

--- a/modules/configuration.py
+++ b/modules/configuration.py
@@ -446,7 +446,7 @@ starting configuration for AT-ST mech walker
         },
         {
             'type': 'confirm',
-            'message': 'shall we build nginx plus web proxy',
+            'message': 'shall we build nginx web proxy',
             'name': 'nginx_web_proxy',
             'default': False,
         },

--- a/terraform/aws/modules/nginx_web_proxy/resources.tf
+++ b/terraform/aws/modules/nginx_web_proxy/resources.tf
@@ -1,11 +1,11 @@
 data "aws_ami" "latest-nginx-plus" {
 count = var.config.nginx_web_proxy == "1" ? 1 : 0
   most_recent = true
-  owners      = ["679593333241"] # Nginx
+  owners      = ["099720109477"] # Nginx
 
   filter {
     name   = "name"
-    values = ["nginx-plus-app-protect-ubuntu-18.04-v2.4-x86_64-developer*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server*"]
   }
 
   filter {


### PR DESCRIPTION
Now that key-value logging appears to be functional in open source NGINX, this PR reworks the nginx proxy server in AWS. Instead of using the AWS Marketplace image that costs $0.30/hour in software licensing fees, this installs OSS NGINX from the Ubuntu repositories. 

~TODO: Update configuration prompt to remove references to "NGINX Plus", testing newer version~