### PR TITLE
Fix issue #650

### DIFF
--- a/ansible/roles/purplesharp/tasks/main.yml
+++ b/ansible/roles/purplesharp/tasks/main.yml
@@ -9,9 +9,8 @@
     If (-not (Test-Path c:\Tools\PurpleSharp\PurpleSharp.exe)) { Invoke-WebRequest -Uri $purplesharpDownloadUrl -OutFile c:\Tools\PurpleSharp\PurpleSharp.exe }
     
 - include_tasks: "run_simulation_playbook.yml"
-  when: run_simulation_playbook == "True"
-
+  when: run_simulation_playbook
 
 - include_tasks: "run_simulation_techniques.yml"
   with_items: "{{ techniques }}"
-  when: run_simulation_playbook == "False"
+  when: not run_simulation_playbook


### PR DESCRIPTION
Fix a small issue preventing the expected `include_tasks` to be run in the PurpleSharp role main task.

Run before the change:
![image](https://user-images.githubusercontent.com/58239192/185664948-c4f3d742-5abc-49a1-b89f-a38553159cb5.png)

After the fix:
![image](https://user-images.githubusercontent.com/58239192/185665131-35bcf987-4b2c-4382-937f-34031aec1536.png)
