### PR TITLE
Properly mark the relevant Ansible task as failed when PurpleSharp Si…

### DIFF
--- a/ansible/roles/purplesharp/tasks/run_simulation_techniques.yml
+++ b/ansible/roles/purplesharp/tasks/run_simulation_techniques.yml
@@ -1,14 +1,21 @@
+
 - debug:
     var: techniques
-    
-- name: Run PurpleSharp Simulation Techniques
-  win_command: PurpleSharp.exe /t "{{ techniques }}" 
-  register: output_purplesharp
-  args:
-    chdir: C:\\Tools\\PurpleSharp  
 
-- name: Save PurpleSharp output
-  set_fact:
-    output_purplesharp: "{{ output_purplesharp }}"
-    cacheable: yes
-  #when: var_str == 'no'
+- name: Run PurpleSharp Simulation Techniques
+  block:
+    - name: Run PurpleSharp Simulation Techniques
+      win_command: PurpleSharp.exe /t "{{ techniques }}"
+      register: output_purplesharp
+      args:
+        chdir: C:\\Tools\\PurpleSharp
+      # Fail this step when PurpleSharp reports the simulation has failed.
+      # The PurpleSharp output details will still be printed for the user to review details.
+      failed_when: "'Simulation Failed' in output_purplesharp.stdout"
+
+  always:
+    - name: Save PurpleSharp output
+      set_fact:
+        output_purplesharp: "{{ output_purplesharp }}"
+        cacheable: yes
+      #when: var_str == 'no'

--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -383,21 +383,21 @@ class TerraformController(IEnvironmentController):
                                 extravars={'ansible_port': ansible_port, 'var_str': var_str, 'run_simulation_playbook': run_simulation_playbook, 'simulation_playbook': simulation_playbook, 'techniques': simulation_techniques, 'ansible_user': ansible_user, 'ansible_password': self.config['attack_range_password']},
                                 verbosity=0)
 
-            if runner.status == "successful":
-                output = []
-                if 'output_purplesharp' in runner.get_fact_cache(target_public_ip):
-                    stdout_lines = runner.get_fact_cache(target_public_ip)['output_purplesharp']['stdout_lines']
-                    print('PurpleSharp Simulation Results:\n')
-                    output.append('PurpleSharp Simulation Results:')
-                    for line in stdout_lines:
-                        output.append(line)
-                        print(line)
-                    return output
+            output = []
+            if 'output_purplesharp' in runner.get_fact_cache(target_public_ip):
+                stdout_lines = runner.get_fact_cache(target_public_ip)['output_purplesharp']['stdout_lines']
+                print('PurpleSharp Simulation Results:\n')
+                output.append('PurpleSharp Simulation Results:')
+                for line in stdout_lines:
+                    output.append(line)
+                    print(line)
+                return output
 
-            else:
+            if runner.status != "successful":
                 self.log.error("failed to execute PurpleSharp simulation against target: {0}".format(
                     target))
                 sys.exit(1)
+
 
     def getPreludeToken(self, TOKEN_PATH):
         TOKEN = ''


### PR DESCRIPTION
Properly mark the relevant Ansible step as failed when a PurpleSharp simulation technique fails, while still showing the user the details of the PurpleSharp tool output for further troubleshooting.

This will ensure users are properly alerted to issues running PS simulations.

Example run with the changes:

![image](https://user-images.githubusercontent.com/58239192/185678322-6ef7c1bd-11a2-44bf-bdfa-62aef830f23a.png)

