### PR TITLE
fixing issue 670 - selecting packer with local 

### DIFF
--- a/modules/configuration.py
+++ b/modules/configuration.py
@@ -218,7 +218,7 @@ starting configuration for AT-ST mech walker
             'type': 'confirm',
             'message': 'do you want to use packer for prebuilt images?',
             'name': 'use_packer',
-            'default': False,
+            'when': lambda answers: answers['provider'] != 'local',
         },
     ]
 


### PR DESCRIPTION
Skips `pre-built-image` question when local provider is selected in configure

![Screenshot from 2022-10-11 15-41-02](https://user-images.githubusercontent.com/1476868/195184287-c7445f9b-89b5-4ac1-ab27-a88eb9a919b2.png)
