### PR TITLE
fixes warning when running docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN cd terraform/aws && terraform init
 RUN cd terraform/azure && terraform init
 RUN pip3 install poetry
 RUN poetry install 
-RUN pip3 install --upgrade awscli
+RUN pip3 install --upgrade awscli requests
 RUN pip3 install azure-cli
 
 COPY docker-entrypoint.sh ./


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1476868/198353198-a4636e6c-2f3e-435e-8d1b-67235ff5a267.png)

looks to be an issue with an out-of-date `requests` lib. 