### PR TITLE
SLACK_WEBHOOK fix part 2: Electric Boogaloo

### DIFF
--- a/.github/workflows/destroy_old_attack_ranges.yml
+++ b/.github/workflows/destroy_old_attack_ranges.yml
@@ -36,4 +36,4 @@ jobs:
         run: |
           poetry run python scripts/attack_range_destroyer.py
         env:
-          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
`env` variables are case sensitive here, so we should make sure we use the correct case.