### PR TITLE
Fail when requested technique is not available - fix issue 709

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ We welcome feedback and contributions from the community! Please see our [contri
 * [Mauricio Velazco](https://twitter.com/mvelazco)
 * [Teoderick Contreras](https://twitter.com/tccontre18)
 * [Lou Stella](https://twitter.com/ljstella)
-* [Christian Cloutier](https://github.com/ccloutier-splunk)
+* [Christian Cloutier](https://github.com/ccl0utier)
 * Eric McGinnis
 * [Micheal Haag](https://twitter.com/M_haggis)
 * Gowthamaraj Rajendran

--- a/modules/ansible/roles/atomic_red_team/tasks/run_art_test_windows.yml
+++ b/modules/ansible/roles/atomic_red_team/tasks/run_art_test_windows.yml
@@ -4,6 +4,21 @@
 - debug:
     var: technique
 
+- name: List available Atomic Red Team Techniques
+  ansible.windows.win_find:
+    paths: C:\AtomicRedTeam\atomics
+    file_type: directory
+    patterns: T*
+  register: available_techniques
+
+- set_fact:
+    available_techniques: "{{ available_techniques | json_query('files[].filename') }}"
+
+- name: Check requested Technique is valid
+  fail:
+    msg: "The selected technique {{ technique }} has no atomic tests. Please ensure it it correct and that tests exist for it. See https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/Indexes/Indexes-CSV/windows-index.csv."
+  when: "technique not in available_techniques"
+  
 - name: Get requirements for Atomic Red Team Technique
   win_shell: |
     Import-Module "C:\AtomicRedTeam\invoke-atomicredteam\Invoke-AtomicRedTeam.psd1" -Force


### PR DESCRIPTION
Validate the requested ART simulated technique against available ones by checking the list of atomics.
Fail with a better message for users if the technique requested is incorrect or there are no matching ART tests.

For example, requesting to simulate invalid technique `T1000` would yield:
<img width="974" alt="image" src="https://user-images.githubusercontent.com/58239192/203650162-074a45ed-b8c2-4a06-a272-631375fc7583.png">

Fix for issue #709.