### PR TITLE
UYpdated variable for attack_range_name

### DIFF
--- a/modules/configuration.py
+++ b/modules/configuration.py
@@ -358,7 +358,7 @@ starting configuration for AT-ST mech walker
                 # get range name
                 'type': 'text',
                 'message': 'enter attack_range name, multiple can be build under different names in the same region',
-                'name': 'range_name',
+                'name': 'attack_range_name',
                 'default': "ar",
             },
 
@@ -396,7 +396,7 @@ starting configuration for AT-ST mech walker
         
         # rest of configs
         configuration['general']['ip_whitelist'] = answers['ip_whitelist']
-        configuration['general']['range_name'] = answers['range_name']
+        configuration['general']['attack_range_name'] = answers['attack_range_name']
 
     print("> configuring attack_range environment")
 

--- a/packer/ansible/roles/guacamole/tasks/guacamole_client.yml
+++ b/packer/ansible/roles/guacamole/tasks/guacamole_client.yml
@@ -8,7 +8,7 @@
 
 - name: Download Guacamole Client
   get_url:
-    url: https://downloads.apache.org/guacamole/1.4.0/binary/guacamole-1.4.0.war
+    url: https://archive.apache.org/dist/guacamole/1.4.0/source/guacamole-client-1.4.0.tar.gz
     dest: /tmp/guacamole-1.4.0.war
 
 - name: Move .war

--- a/packer/ansible/roles/guacamole/tasks/guacamole_server.yml
+++ b/packer/ansible/roles/guacamole/tasks/guacamole_server.yml
@@ -2,7 +2,7 @@
 
 - name: Download Guacamole
   get_url: 
-    url: https://downloads.apache.org/guacamole/1.4.0/source/guacamole-server-1.4.0.tar.gz
+    url: https://archive.apache.org/dist/guacamole/1.4.0/source/guacamole-server-1.4.0.tar.gz 
     dest: /tmp/guacamole-server-1.4.0.tar.gz
 
 - name: Extract the source tarball after download


### PR DESCRIPTION
Contains fixes for issues:
- https://github.com/splunk/attack_range/issues/757
- https://github.com/splunk/attack_range/issues/759

the configure command created yml file with `range_name` which is incorrect. It should be creating a yml file with attack_range_name. 
New yml file :

![image](https://user-images.githubusercontent.com/7771446/220488892-a42ff05f-9f2b-458f-95fd-fe0423139f23.png)

Fix for issue: 
https://github.com/splunk/attack_range/issues/757