### PR TITLE
Fix Configure for Azure Location

### DIFF
--- a/modules/configuration.py
+++ b/modules/configuration.py
@@ -387,7 +387,7 @@ starting configuration for AT-ST mech walker
             if configuration['general']['cloud_provider'] == "aws":
                 configuration['aws']['region'] = answers['region']
             else:
-                configuration['azure']['region'] = answers['region']
+                configuration['azure']['location'] = answers['region']
         else:
             if configuration['general']['cloud_provider'] == "aws":
                 configuration['aws']['region'] = 'eu-central-1'


### PR DESCRIPTION
In the azure configuration, the region is called `location` instead of `region`. If `region` is set, the build ignores this and uses the default `location` of West Europe.

This fixes that issue.