### PR TITLE
Bugfix for #795

### DIFF
--- a/packer/ansible/nginx_web_proxy.yml
+++ b/packer/ansible/nginx_web_proxy.yml
@@ -1,5 +1,8 @@
 - hosts: all
   gather_facts: False
   become: true
+  vars:
+    proxy_server_ip: "10.0.1.12"
+    proxy_server_port: "8000"
   roles:
     - nginx_web_proxy

--- a/packer/ansible/roles/nginx_web_proxy/tasks/main.yml
+++ b/packer/ansible/roles/nginx_web_proxy/tasks/main.yml
@@ -7,7 +7,9 @@
 
 - name: restart splunk
   become: true
-  command: "/opt/splunkforwarder/bin/splunk restart"
+  service:
+    name: SplunkForwarder
+    state: restarted
 
 - name: restart nginx again
   become: true

--- a/packer/ansible/roles/nginx_web_proxy/templates/default.conf.j2
+++ b/packer/ansible/roles/nginx_web_proxy/templates/default.conf.j2
@@ -7,7 +7,7 @@ server {
     location / {
     #    root   /usr/share/nginx/html;
     #    index  index.html index.htm;
-         proxy_pass   http://{{nginx_web_proxy_host}}:{{nginx_web_proxy_port}};
+         proxy_pass   http://{{proxy_server_ip}}:{{proxy_server_port}};
     }
 
     #error_page  404              /404.html;


### PR DESCRIPTION
Simple bugfixes for #795:

`terraform/ansible/roles/nginx_server_post/templates/default.conf.j2` referencing variables that did not exist.
Standardises the NGINX variables to the same naming convention used elsewhere in the repo.

The variables are passed through during the build at the Terraform stage, but they do not exist yet during the Packer build stage and hence it fails. Added the default value variables to prevent the failure. If custom values are defined, they will be overwritten during the post builds with Ansible anyway.

Finally, the restart of Splunk was also failing. The code was modified to use systemctl instead of a command to rectify the issue as requested by the error message. 

These issues combined were preventing a successful AWS Packer build of NGINX.