### PR TITLE
Bugfix for #830 (Splunk UFW (linux) journald reading)

### DIFF
--- a/packer/ansible/roles/linux_universal_forwarder/tasks/install_universal_forwarder.yml
+++ b/packer/ansible/roles/linux_universal_forwarder/tasks/install_universal_forwarder.yml
@@ -45,6 +45,12 @@
 - name: setup to start at boot
   become: true
   command: "/opt/splunkforwarder/bin/splunk enable boot-start -user splunk"
+  
+- name: Add splunk user to systemd-journal group
+  user:
+    name: splunk
+    groups: systemd-journal
+    append: yes
 
 - name: Start splunk uf
   become: true


### PR DESCRIPTION
Splunk Universal Forwarder on linux VMs needs permission to read journald events (e.g. from sysmon).
This PR grants it by adding splunk user to systemd-journal group.