### PR TITLE
Change Splunk UFW (linux) to systemd-managed boot start

### DIFF
--- a/packer/ansible/roles/linux_universal_forwarder/tasks/install_universal_forwarder.yml
+++ b/packer/ansible/roles/linux_universal_forwarder/tasks/install_universal_forwarder.yml
@@ -44,7 +44,7 @@
 
 - name: setup to start at boot
   become: true
-  command: "/opt/splunkforwarder/bin/splunk enable boot-start -user splunk"
+  command: "/opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk"
 
 - name: Start splunk uf
   become: true


### PR DESCRIPTION
In modern linux distributions managing services with init.d scripts is deprecated and systemd used instead.
