### PR TITLE
Phantom update

### DIFF
--- a/packer/ansible/roles/phantom/tasks/add_vault_mirrors.yml
+++ b/packer/ansible/roles/phantom/tasks/add_vault_mirrors.yml
@@ -1,0 +1,8 @@
+---
+# Add vault mirrors to centos due to EOL
+
+- name: comment out old mirrors
+  shell: sudo sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-*
+
+- name: add vault mirrors
+  shell: sudo sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*

--- a/packer/ansible/roles/phantom/tasks/install_phantom_local.yml
+++ b/packer/ansible/roles/phantom/tasks/install_phantom_local.yml
@@ -14,8 +14,8 @@
 - name: prepare phantom install script without apps
   shell: sudo /home/vagrant/splunk-soar/soar-prepare-system --splunk-soar-home /opt/soar --no-prompt 
 
-- name: copy splunk soar folder
-  shell: cp -r /home/vagrant/splunk-soar /home/phantom/splunk-soar
+- name: move splunk soar folder
+  shell: mv /home/vagrant/splunk-soar /home/phantom/splunk-soar
 
 - name: chown splunk soar folder
   shell: chown -R phantom. /home/phantom/splunk-soar

--- a/packer/ansible/roles/phantom/tasks/main.yml
+++ b/packer/ansible/roles/phantom/tasks/main.yml
@@ -2,6 +2,8 @@
 # This playbook contains common tasks in this role
 - include: add_vault_mirrors.yml
 
+- include: resize_disk.yml
+
 - include: install_phantom.yml
   when: cloud_provider != "local"
 

--- a/packer/ansible/roles/phantom/tasks/main.yml
+++ b/packer/ansible/roles/phantom/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 # This playbook contains common tasks in this role
+- include: add_vault_mirrors.yml
 
 - include: install_phantom.yml
   when: cloud_provider != "local"

--- a/packer/ansible/roles/phantom/tasks/resize_disk.yml
+++ b/packer/ansible/roles/phantom/tasks/resize_disk.yml
@@ -1,0 +1,17 @@
+---
+# Resize the disk to use all available space
+- name: Install the EPEL repository
+  yum:
+    name: epel-release
+    state: present
+
+- name: Install cloud-utils-growpart
+  yum:
+    name: cloud-utils-growpart
+    state: present
+
+- name: Use growpart to resize partition 1
+  shell: sudo growpart /dev/sda 1
+
+- name: Use xfs_growfs to resize the filesystem
+  shell: sudo xfs_growfs /dev/sda1

--- a/vagrant/phantom_server/Vagrantfile
+++ b/vagrant/phantom_server/Vagrantfile
@@ -1,6 +1,7 @@
 config.vm.define "ar-phantom-{{config.general.key_name}}-{{config.general.attack_range_name}}" do |config|
     VM_NAME_P= "ar-phantom"
-    config.vm.box = "centos/7"
+    config.vm.box = "centos/8"
+    config.vm.disk :disk, size: "50GB", primary: true
     config.vm.hostname = "#{VM_NAME_P}"
     config.vm.boot_timeout = 600
     config.vm.network "forwarded_port", guest: 443, host: 8443, protocol: "tcp"

--- a/vagrant/phantom_server/Vagrantfile
+++ b/vagrant/phantom_server/Vagrantfile
@@ -1,7 +1,7 @@
 config.vm.define "ar-phantom-{{config.general.key_name}}-{{config.general.attack_range_name}}" do |config|
     VM_NAME_P= "ar-phantom"
     config.vm.box = "centos/8"
-    config.vm.disk :disk, size: "50GB", primary: true
+    config.vm.disk :disk, size: "25GB", primary: true
     config.vm.hostname = "#{VM_NAME_P}"
     config.vm.boot_timeout = 600
     config.vm.network "forwarded_port", guest: 443, host: 8443, protocol: "tcp"


### PR DESCRIPTION
This implements the fixes I mentioned in #855. Key features are:

* Update the Phantom box to use Centos/8
* Resize the Phantom disk to 25GB - useful for SOAR recommendations, only 13GB is currently used
* Fix the mirrors for Phantom

Boxes appeared to successfully build after these changes, but I am not very familiar with Splunk and did not test functionality, only a successful `python3 ./attack_range.py build` command.