### PR TITLE
Add functions to modify (stop, resume) specific instances in AWS

### DIFF
--- a/attack_range.py
+++ b/attack_range.py
@@ -89,11 +89,13 @@ def destroy(args):
 
 def stop(args):
     controller = init(args)
-    controller.stop()
+    instance_ids = [id.strip() for id in args.instance_ids.split(',')] if args.instance_ids else None
+    controller.stop(instance_ids)
     
 def resume(args):
     controller = init(args)
-    controller.resume()
+    instance_ids = [id.strip() for id in args.instance_ids.split(',')] if args.instance_ids else None
+    controller.resume(instance_ids)
 
 def packer(args):
     controller = init(args)
@@ -155,9 +157,11 @@ def main(args):
 
     # Stop arguments
     stop_parser.set_defaults(func=stop)
+    stop_parser.add_argument("--instance_ids", required=False, type=str, help="comma-separated list of instance IDs to stop")
 
     # Resume arguments
     resume_parser.set_defaults(func=resume)
+    resume_parser.add_argument("--instance_ids", required=False, type=str, help="comma-separated list of instance IDs to resume")
 
     # Packer agruments
     packer_parser.add_argument("-in", "--image_name", required=True, type=str,

--- a/modules/aws_service.py
+++ b/modules/aws_service.py
@@ -41,6 +41,14 @@ def get_instance_by_name(ec2_name, key_name, ar_name, region):
         str = instance['Tags'][0]['Value']
         if str == ec2_name:
             return instance
+        
+def get_instances_by_ids(instance_ids, ec2_name, key_name, ar_name, region):
+    instances = get_all_instances(key_name, ar_name, region)
+    result = []
+    for instance in instances:
+        if instance['InstanceId'] in instance_ids:
+            result.append(instance)
+    return result
 
 
 def get_single_instance_public_ip(ec2_name, key_name, ar_name, region):


### PR DESCRIPTION
Added code to control specific instances on AWS based on IDs.
**Supported modifications:**
1. Resume
2. Stop

**Cmd:**
`python attack_range.py resume --instance_ids "i-02b4xxx, i-0dece1xxxx"`
`python attack_range.py stop --instance_ids "i-02b4xxx, i-0dece1xxxx"`