### PR TITLE
bug: fix config regression

### DIFF
--- a/configs/attack_range_default.yml
+++ b/configs/attack_range_default.yml
@@ -43,6 +43,9 @@ general:
 # All these fields are needed to automatically deploy a Carbon Black Agent and ingest Carbon Black logs into the Splunk Server.
 # See the chapter Carbon Black in the docs page Attack Range Features.
 
+install_contentctl: "0"
+# Install splunk/contentctl on linux servers
+
 aws:
   region: "us-west-2"
 # Region used in AWS. This should be the same as the region configured in AWS CLI.


### PR DESCRIPTION
Previous commits erased the `install_contentctl` config flag which caused ansible errors near the end of a build including linux servers.