### PR TITLE
Moved CLI-only flags for osquery to flags file and commented out in osquery conf

### DIFF
--- a/packer/ansible/roles/osquery_linux/files/custom_osquery.flags
+++ b/packer/ansible/roles/osquery_linux/files/custom_osquery.flags
@@ -7,3 +7,5 @@
 --events_max=500000
 --logger_min_status=1
 --logger_plugin=filesystem
+--config_plugin=filesystem
+--database_path='/var/osquery/osquery.db'

--- a/packer/ansible/roles/osquery_linux/files/template.osquery.conf
+++ b/packer/ansible/roles/osquery_linux/files/template.osquery.conf
@@ -2,10 +2,10 @@
   // Configure the daemon below:
   "options": {
     // Select the osquery config plugin.
-    "config_plugin": "filesystem",
+    //"config_plugin": "filesystem",
 
     // Select the osquery logging plugin.
-    "logger_plugin": "filesystem",
+    //"logger_plugin": "filesystem",
 
     // The log directory stores info, warning, and errors.
     // If the daemon uses the 'filesystem' logging retriever then the log_dir
@@ -23,7 +23,7 @@
 
     // A filesystem path for disk-based backing storage used for events and
     // query results differentials. See also 'use_in_memory_database'.
-    "database_path": "/var/osquery/osquery.db",
+    //"database_path": "/var/osquery/osquery.db",
 
     // Comma-delimited list of table names to be disabled.
     // This allows osquery to be launched without certain tables.


### PR DESCRIPTION
Running osquery on the linux lab host results in the following error output being produced:
```
The CLI only flag --config_plugin set via config file will be ignored, please use a flagfile or pass it to the process at startup
The CLI only flag --logger_plugin set via config file will be ignored, please use a flagfile or pass it to the process at startup
The CLI only flag --database_path set via config file will be ignored, please use a flagfile or pass it to the process at startup
```

This PR moves the relevant config entries out of `osquery.conf`, and provides them as flags in `osquery.flags`.