### PR TITLE
Update configuration.py

### DIFF
--- a/modules/configuration.py
+++ b/modules/configuration.py
@@ -53,7 +53,7 @@ def create_key_pair_aws(region):
     epoch_time = str(int(time.time()))
     ssh_key_name = getpass.getuser() + "-" + epoch_time[-5:] + ".key"
     # create ssh keys
-    response = client.create_key_pair(KeyType='ed25519', KeyName=str(ssh_key_name)[:-4])
+    response = client.create_key_pair(KeyType='rsa', KeyName=str(ssh_key_name)[:-4])
     with open(ssh_key_name, "w") as ssh_key:
         ssh_key.write(response['KeyMaterial'])
     os.chmod(ssh_key_name, 0o600)


### PR DESCRIPTION
Update key creation as AWS no longer allows ed25519 for windows AMIs.

```
│ Error: creating EC2 Instance: Unsupported: ED25519 key pairs are not supported with Windows AMIs. Choose a different key pair type and try again. │ 	status code: 400, request id: 4677fe72-5c49-4702-9490-351dc13bfcbc │
│   with module.windows-server.aws_instance.windows_server[0],
│   on modules/windows/resources.tf line 33, in resource "aws_instance" "windows_server":
│   33: resource "aws_instance" "windows_server" {
│
```