### PR TITLE
Update inputs.conf with Additional Zeek Logs

### DIFF
--- a/packer/ansible/roles/zeek_sensor/files/inputs.conf
+++ b/packer/ansible/roles/zeek_sensor/files/inputs.conf
@@ -1,6 +1,31 @@
 [default]
 host = zeek
 
+[monitor:///opt/zeek/logs/current/weird.log]
+_TCP_ROUTING = *
+index = zeek
+sourcetype = bro:weird:json
+
+[monitor:///opt/zeek/logs/current/notice.log]
+_TCP_ROUTING = *
+index = zeek
+sourcetype = bro:notice:json
+
+[monitor:///opt/zeek/logs/current/ntlm.log]
+_TCP_ROUTING = *
+index = zeek
+sourcetype = bro:ntlm:json
+
+[monitor:///opt/zeek/logs/current/kerberos.log]
+_TCP_ROUTING = *
+index = zeek
+sourcetype = bro:kerberos:json
+
+[monitor:///opt/zeek/logs/current/dce_rpc.log]
+_TCP_ROUTING = *
+index = zeek
+sourcetype = bro:dce_rpc:json
+
 [monitor:///opt/zeek/logs/current/conn.log]
 _TCP_ROUTING = *
 index = zeek


### PR DESCRIPTION
Some useful Zeek logs are not being forwarded to Splunk, most notably this includes those relating to DCE/RPC, NTLM and Kerberos.

This PR adds these to the zeek inputs.conf file used by the Splunk Forwarder.