### PR TITLE
Swapping Linux Sysmon TA

### DIFF
--- a/packer/ansible/roles/linux_sysmon/files/inputs.conf
+++ b/packer/ansible/roles/linux_sysmon/files/inputs.conf
@@ -6,4 +6,4 @@ journalctl-exclude-fields = __MONOTONIC_TIMESTAMP,__SOURCE_REALTIME_TIMESTAMP
 journalctl-filter = _SYSTEMD_UNIT=sysmon.service
 index = unix
 source = Syslog:Linux-Sysmon/Operational
-sourcetype = sysmon_linux
+sourcetype = sysmon:linux

--- a/packer/ansible/roles/splunk_server/tasks/main.yml
+++ b/packer/ansible/roles/splunk_server/tasks/main.yml
@@ -22,7 +22,7 @@
     - "splunk-machine-learning-toolkit_541.tgz"
     - "splunk-security-essentials_380.tgz"
     - "splunk-add-on-for-sysmon_400.tgz "
-    - "add-on-for-linux-sysmon_104.tgz"
+    - "splunk-add-on-for-sysmon-for-linux_100.tgz"
     - "splunk-add-on-for-amazon-web-services-aws_760.tgz"
     - "splunk-add-on-for-microsoft-office-365_451.tgz"
     - "splunk-add-on-for-amazon-kinesis-firehose_131r7d1d093.tgz"

--- a/packer/ansible/roles/sysmon_linux/files/deb_template_inputs.conf
+++ b/packer/ansible/roles/sysmon_linux/files/deb_template_inputs.conf
@@ -6,4 +6,4 @@ journalctl-exclude-fields = __MONOTONIC_TIMESTAMP,__SOURCE_REALTIME_TIMESTAMP
 journalctl-filter = _SYSTEMD_UNIT=sysmon.service
 index = unix
 source = Syslog:Linux-Sysmon/Operational
-sourcetype = sysmon_linux
+sourcetype = sysmon:linux


### PR DESCRIPTION
We swapped the now-archived community created Linux Sysmon TA out for the Splunk-supported one in our testing infra and detections- we should update the range to build with this as well.

I _think_ I got all of the places we either
1) reference the app 
2) reference the old sourcetype.