### PR TITLE
Fix Docutils issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,12 @@ questionary = "^1.10.0"
 Jinja2 = "^3.1.2"
 python-vagrant = "^1.0.0"
 
+# Fix issue with docutils ".post1" release
+# https://github.com/python-poetry/poetry/issues/9293#issuecomment-2048205226
+[[tool.poetry.source]]
+name = "pypi-public"
+url = "https://pypi.org/simple/"
+
 [tool.poetry.dev-dependencies]
 
 [build-system]


### PR DESCRIPTION
The following issue makes `poetry install` fail due to a *.postN release of docutils:
https://github.com/python-poetry/poetry/issues/9293#issuecomment-2048205226

We have added the workaround in the pyproject.yml file to help find the relevant release.

This is required because the poetry install failure means that, without a lock file, attack_range cannot be installed locally and the workflow which deploys it to Docker Hub also fails.