### PR TITLE
osquery_service_started

### DIFF
--- a/packer/ansible/roles/linux_osquery/tasks/install_osquery_linux.yml
+++ b/packer/ansible/roles/linux_osquery/tasks/install_osquery_linux.yml
@@ -51,19 +51,20 @@
     src: custom_osquery.flags
     dest: /etc/osquery/osquery.flags
 
-- name: activate osqueryd service
+- name: Ensure osqueryd service is enabled
   become: true
-  service:
+  systemd:
+    name: osqueryd
+    enabled: yes
+
+- name: Ensure osqueryd service is started
+  become: true
+  systemd:
     name: osqueryd
     state: started
 
-- name: osqueryd service status check
-  become: true
-  command: systemctl status osqueryd
-  register: osq_service_status
 
-- name: osquery service status stdout
-  debug: msg="{{ osq_service_status.stdout }}"
+
 
 
 


### PR DESCRIPTION
notice that osquery service is not started upon the build of attack range this changes fix the issue 

![Screenshot 2024-07-05 at 13 46 33](https://github.com/splunk/attack_range/assets/26181693/c220d82b-6051-4878-994d-16e4ad496a0b)
