### PR TITLE
Ubuntu 20.04 Acl installation fix

### DIFF
--- a/packer/ansible/roles/linux_common/tasks/update_packages.yml
+++ b/packer/ansible/roles/linux_common/tasks/update_packages.yml
@@ -3,6 +3,7 @@
 - name: Install Acl
   apt:
     name: acl
+    update_cache: true 
     state: present
 
 - name: Install Acl Retry

--- a/packer/ansible/roles/zeek_sensor/files/inputs.conf
+++ b/packer/ansible/roles/zeek_sensor/files/inputs.conf
@@ -1,6 +1,31 @@
 [default]
 host = zeek
 
+[monitor:///opt/zeek/logs/current/weird.log]
+_TCP_ROUTING = *
+index = zeek
+sourcetype = bro:weird:json
+
+[monitor:///opt/zeek/logs/current/notice.log]
+_TCP_ROUTING = *
+index = zeek
+sourcetype = bro:notice:json
+
+[monitor:///opt/zeek/logs/current/ntlm.log]
+_TCP_ROUTING = *
+index = zeek
+sourcetype = bro:ntlm:json
+
+[monitor:///opt/zeek/logs/current/kerberos.log]
+_TCP_ROUTING = *
+index = zeek
+sourcetype = bro:kerberos:json
+
+[monitor:///opt/zeek/logs/current/dce_rpc.log]
+_TCP_ROUTING = *
+index = zeek
+sourcetype = bro:dce_rpc:json
+
 [monitor:///opt/zeek/logs/current/conn.log]
 _TCP_ROUTING = *
 index = zeek

--- a/packer/ansible/roles/zeek_sensor/files/inputs.conf
+++ b/packer/ansible/roles/zeek_sensor/files/inputs.conf
@@ -1,31 +1,6 @@
 [default]
 host = zeek
 
-[monitor:///opt/zeek/logs/current/weird.log]
-_TCP_ROUTING = *
-index = zeek
-sourcetype = bro:weird:json
-
-[monitor:///opt/zeek/logs/current/notice.log]
-_TCP_ROUTING = *
-index = zeek
-sourcetype = bro:notice:json
-
-[monitor:///opt/zeek/logs/current/ntlm.log]
-_TCP_ROUTING = *
-index = zeek
-sourcetype = bro:ntlm:json
-
-[monitor:///opt/zeek/logs/current/kerberos.log]
-_TCP_ROUTING = *
-index = zeek
-sourcetype = bro:kerberos:json
-
-[monitor:///opt/zeek/logs/current/dce_rpc.log]
-_TCP_ROUTING = *
-index = zeek
-sourcetype = bro:dce_rpc:json
-
 [monitor:///opt/zeek/logs/current/conn.log]
 _TCP_ROUTING = *
 index = zeek


### PR DESCRIPTION
It looks like a previous [issue](https://github.com/splunk/attack_range/issues/804) where the ACL package doesn't install on Ubuntu 20.04 has resurfaced. 

This PR updates the cache for the `apt` module which seems to resolve the issue and successful installs `acl`. 