### PR TITLE
add dependencies for osquery install script

### DIFF
--- a/packer/ansible/roles/linux_osquery/tasks/install_osquery_linux.yml
+++ b/packer/ansible/roles/linux_osquery/tasks/install_osquery_linux.yml
@@ -1,5 +1,11 @@
 ---
-# This playbook install the isquery in linux machine
+# This playbook installs osquery on a linux machine
+- name: Install required system packages
+  become: true
+  apt:
+    name: software-properties-common
+    state: present    
+    update_cache: true
 
 - name: drop the osquery_install.sh script /tmp
   become: true


### PR DESCRIPTION
The `add-apt-repository` command is used in the `osquery_install.sh` script. This PR ensures the `software-properties-common` package is installed so that this runs successfully.
