### PR TITLE
Update Attack_Range_AWS.md

### DIFF
--- a/docs/source/Attack_Range_AWS.md
+++ b/docs/source/Attack_Range_AWS.md
@@ -54,17 +54,17 @@ apt-get update
 apt-get install -y python3.8 git unzip python3-pip curl
 ````
 
-Clone attack_range git repo to local machine:
-````bash
-git clone https://github.com/splunk/attack_range.git
-cd attack_range
-````
-
 Install and configure Terraform:
 ````bash
 curl -s https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_linux_amd64.zip -o terraform.zip && \
 unzip terraform.zip && \
 mv terraform /usr/local/bin/
+````
+
+Clone attack_range git repo to local machine:
+````bash
+git clone https://github.com/splunk/attack_range.git
+cd attack_range
 ````
 
 Install the AWS CLI:


### PR DESCRIPTION
Move the Install and Configure Terraform step before cloning and cd to attack_range.  If done afterwards you get an error because a directory already exist with the name "terraform"

root@ip-10-44-3-28:/home/ubuntu/attack_range# curl -s https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_linux_amd64.zip -o terraform.zip && \ unzip terraform.zip && \
mv terraform /usr/local/bin/
Archive:  terraform.zip
replace terraform? [y]es, [n]o, [A]ll, [N]one, [r]ename: y error:  cannot delete old terraform
        Is a directory