### PR TITLE
MITRE Caldera

### DIFF
--- a/attack_range.yml
+++ b/attack_range.yml
@@ -1,8 +1,0 @@
-# all available parameters can be seen in configs/attack_range_default.yml
-general:
-  attack_range_password: "ChangeMe123!"
-  cloud_provider: "aws"
-  key_name: "ar"
-windows_servers:
-  - hostname: ar-win 
-    image: windows-2016-v3-0-0

--- a/configs/attack_range_default.yml
+++ b/configs/attack_range_default.yml
@@ -209,6 +209,9 @@ windows_servers_default:
   # Install Bad Blood by setting this to 1 or 0.
   # More information in chapter Bad Blood under Attack Range Features.
 
+  install_caldera_agent: "0"
+  # Install a MITRE Caldera agent that connects to the Caldera Server.
+
   install_crowdstrike: "0"
   # Install CrowdStrike Falcon by setting this to 1.
 
@@ -252,6 +255,9 @@ linux_servers_default:
   cisco_secure_endpoint_linux_agent: "amp_Server_ubuntu-20-04-amd64.deb"
   # Name of the Cisco Secure Endpoint Linux Agent stored in apps/ folder.
 
+  install_caldera_agent: "0"
+  # Install a MITRE Caldera agent that connects to the Caldera Server.
+
 kali_server:
   kali_server: "0"
 # Enable Kali Server by setting this to 1.
@@ -276,6 +282,34 @@ zeek_server:
 snort_server:
   snort_server: "0"
   # Enable Snort Server by setting this to 1.
+
+caldera_server:
+  caldera_server: "0"
+  # Enable MITRE Caldera Server by setting this to 1.
+
+  hostname: "caldera"
+  # Specify the image used for Caldera Server.
+
+  # ------ Changing below this line could break MITRE Caldera -------------- #
+
+  caldera_version: ""
+  # MITRE Caldera Version to install (https://github.com/mitre/caldera/releases). Default: (left blank to pull latest)
+  # caldera_version: "--branch 5.0.0"
+
+  go_version: "1.23.3"
+  # GO version to install (https://go.dev/dl/).
+
+  nvm_version: "0.40.1"
+  # NVM version to install (https://github.com/nvm-sh/nvm/releases).
+
+  node_version: "22"
+  # Node version to install (https://nodejs.org/en/download/package-manager).
+
+  upx_version: "4.2.4"
+  # UPX version to install (https://github.com/upx/upx/releases).
+
+  private_ip: "10.0.1.70"
+  # internal ip for the Caldera server (used for agent communication - no need to change).
 
 simulation:
   atomic_red_team_repo: redcanaryco

--- a/modules/aws_controller.py
+++ b/modules/aws_controller.py
@@ -327,6 +327,20 @@ class AwsController(AttackRangeController):
                         + "\n\tusername: ubuntu \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )
+                elif instance_name.startswith("ar-caldera"):
+                    messages.append(
+                        "\nAccess Caldera via:\n\tWeb > http://"
+                        + instance["NetworkInterfaces"][0]["Association"]["PublicIp"]
+                        + ":8888"
+                        + "\n\tusername: red \n\tpassword: "
+                        + self.config["general"]["attack_range_password"]
+                        + "\n\tSSH > ssh -i"
+                        + self.config["aws"]["private_key_path"]
+                        + " admin@"
+                        + instance["NetworkInterfaces"][0]["Association"][
+                                "PublicIp"
+                            ]
+                    )
             else:
                 response.append(
                     [instance["Tags"][0]["Value"], instance["State"]["Name"]]

--- a/modules/config_handler.py
+++ b/modules/config_handler.py
@@ -29,6 +29,7 @@ class ConfigHandler:
             "simulation",
             "zeek_server",
             "snort_server",
+            "caldera_server",
         ]
 
         for parent_key in parent_keys:
@@ -148,4 +149,11 @@ class ConfigHandler:
             print(
                 "ERROR: You can not use a phantom server or bring your own phantom when you use a bring your own splunk."
             )
+            sys.exit(1)
+
+        if (
+            config["caldera_server"]["caldera_server"] == "1"
+            and config["general"]["cloud_provider"] == "azure"
+        ):
+            print("ERROR: Caldera Server not supported in Azure.")
             sys.exit(1)

--- a/modules/configuration.py
+++ b/modules/configuration.py
@@ -442,6 +442,13 @@ starting configuration for AT-ST mech walker
             "when": lambda answers: answers["windows_server_one"]
             and answers["windows_server_one_dc"],
         },
+        {
+            "type": "confirm",
+            "message": "should we install a MITRE Caldera agent on the windows server",
+            "name": "windows_server_one_caldera_agent",
+            "default": False,
+            "when": lambda answers: answers["windows_server_one"],
+        },
     ]
 
     answers = questionary.prompt(questions)
@@ -463,6 +470,8 @@ starting configuration for AT-ST mech walker
         if "windows_server_one_bad_blood" in answers:
             if answers["windows_server_one_bad_blood"]:
                 configuration["windows_servers"][0]["bad_blood"] = "1"
+        if answers["windows_server_one_caldera_agent"]:
+            configuration["windows_servers"][0]["install_caldera_agent"] = "1"
 
         questions = [
             {
@@ -493,6 +502,13 @@ starting configuration for AT-ST mech walker
                 "default": False,
                 "when": lambda answers: answers["windows_server_two"],
             },
+            {
+                "type": "confirm",
+                "message": "should we install a MITRE Caldera agent on the windows server",
+                "name": "windows_server_two_caldera_agent",
+                "default": False,
+                "when": lambda answers: answers["windows_server_two"],
+            },
         ]
 
         answers = questionary.prompt(questions)
@@ -510,6 +526,8 @@ starting configuration for AT-ST mech walker
                     configuration["windows_servers"][1]["join_domain"] = "1"
             if answers["windows_server_two_red_team_tools"]:
                 configuration["windows_servers"][1]["install_red_team_tools"] = "1"
+            if answers["windows_server_two_caldera_agent"]:
+                configuration["windows_servers"][1]["install_caldera_agent"] = "1"
 
     questions = [
         {
@@ -517,6 +535,13 @@ starting configuration for AT-ST mech walker
             "message": "shall we build a linux server",
             "name": "linux_server",
             "default": False,
+        },
+        {
+            "type": "confirm",
+            "message": "should we install a MITRE Caldera agent on the linux server",
+            "name": "linux_server_caldera_agent",
+            "default": False,
+            "when": lambda answers: answers["linux_server"],
         },
         {
             "type": "confirm",
@@ -558,6 +583,13 @@ starting configuration for AT-ST mech walker
             "name": "phantom_installer",
             "when": lambda answers: answers["phantom"],
         },
+        {
+            "type": "confirm",
+            "message": "shall we build a MITRE Caldera server for attack simulation",
+            "name": "caldera_server",
+            "default": False,
+            "when": lambda answers: configuration["general"]["cloud_provider"] == "aws",
+        },
     ]
 
     answers = questionary.prompt(questions)
@@ -569,6 +601,9 @@ starting configuration for AT-ST mech walker
                 "hostname": "ar-linux",
             }
         )
+        if "linux_server_caldera_agent" in answers:
+            if answers["linux_server_caldera_agent"]:
+                configuration["linux_servers"][0]["install_caldera_agent"] = "1"
 
     if configuration["general"]["cloud_provider"] == "aws":
         if answers["kali_machine"]:
@@ -586,6 +621,10 @@ starting configuration for AT-ST mech walker
         if answers["snort_server"]:
             configuration["snort_server"] = dict()
             configuration["snort_server"]["snort_server"] = "1"
+        
+        if answers["caldera_server"]:
+            configuration["caldera_server"] = dict()
+            configuration["caldera_server"]["caldera_server"] = "1"
 
     if answers["phantom"]:
         configuration["phantom_server"] = dict()

--- a/terraform/ansible/caldera_eip.yml
+++ b/terraform/ansible/caldera_eip.yml
@@ -1,0 +1,8 @@
+- hosts: all
+  gather_facts: false
+  become: false
+  roles:
+    - role: caldera_server
+      vars:
+        caldera_server_action: "update_eip"
+        caldera_server_skip_start: false

--- a/terraform/ansible/caldera_server.yml
+++ b/terraform/ansible/caldera_server.yml
@@ -1,0 +1,16 @@
+- hosts: all
+  gather_facts: false
+  become: false
+  roles:
+    - role: caldera_server
+      vars:
+        caldera_server_action: "install"
+        caldera_server_skip_start: true
+      when: aws_eip == "1"
+
+    - role: caldera_server
+      vars:
+        caldera_server_action: "install"
+        caldera_server_skip_start: false
+      when: aws_eip == "0"
+

--- a/terraform/ansible/linux_server.yml
+++ b/terraform/ansible/linux_server.yml
@@ -15,3 +15,7 @@
     - contentctl
     - crowdstrike_falcon_agent_linux
     - cisco_secure_endpoint_linux
+    - role: caldera_agent
+      vars:
+        caldera_agent_server_type: "linux"
+      when: caldera_server.caldera_server == "1" and linux_servers.install_caldera_agent == "1"

--- a/terraform/ansible/roles/caldera_agent/tasks/linux.yml
+++ b/terraform/ansible/roles/caldera_agent/tasks/linux.yml
@@ -1,0 +1,4 @@
+---
+- name: Install Linux Agent [Caldera Agent]
+  ansible.builtin.shell: >
+    server="http://{{ caldera_server.private_ip }}:8888";agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:linux" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;nohup ./$agent -server $server &

--- a/terraform/ansible/roles/caldera_agent/tasks/main.yml
+++ b/terraform/ansible/roles/caldera_agent/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Install on Windows [Caldera Agent]
+  ansible.builtin.import_tasks: windows.yml
+  when: caldera_agent_server_type == "windows"
+
+- name: Install on Linux [Caldera Agent]
+  ansible.builtin.import_tasks: linux.yml
+  when: caldera_agent_server_type == "linux"

--- a/terraform/ansible/roles/caldera_agent/tasks/windows.yml
+++ b/terraform/ansible/roles/caldera_agent/tasks/windows.yml
@@ -1,0 +1,39 @@
+---
+- name: Install Windows Agent [Caldera Agent]
+  ansible.windows.win_powershell:
+    parameters:
+      server: "http://{{ caldera_server.private_ip }}:8888"
+    script: |
+      param (
+        [String]$server
+      )
+
+      $url="$server/file/download";
+      $wc=New-Object System.Net.WebClient;
+      $wc.Headers.add("platform","windows");
+      $wc.Headers.add("file","sandcat.go");
+      $data=$wc.DownloadData($url);
+      get-process | ? {$_.modules.filename -like "C:\Temp\splunkd.exe"} | stop-process -f;
+      rm -force "C:\Temp\splunkd.exe" -ea ignore;
+      [io.file]::WriteAllBytes("C:\Temp\splunkd.exe",$data) | Out-Null;
+
+- name: Set scheduled task [Caldera Agent]
+  community.windows.win_scheduled_task:
+    name: CalderaAgent
+    description: Connects to caldera C2 server - don't look here xD
+    actions:
+      - path: C:\Temp\splunkd.exe
+        arguments: -server http://{{ caldera_server.private_ip }}:8888 -group red
+    triggers:
+      - type: boot
+    username: "ATTACKRANGE\\Administrator"
+    password: "{{ general.attack_range_password }}"
+    run_level: highest
+    hidden: true
+    state: present
+    enabled: true
+    allow_demand_start: true
+    logon_type: password
+
+- name: Start agent [Caldera Agent]
+  ansible.windows.win_command: SCHTASKS.EXE /RUN /I /TN CalderaAgent

--- a/terraform/ansible/roles/caldera_server/files/caldera.service
+++ b/terraform/ansible/roles/caldera_server/files/caldera.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Caldera Service
+After=network.target
+
+[Service]
+Type=simple
+User=admin
+Group=admin
+KillSignal=SIGINT #workaround (works with this parameter)
+EnvironmentFile=/home/admin/caldera/caldera.env
+WorkingDirectory=/home/admin/caldera
+ExecStart=pipenv run python server.py --insecure --build
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/ansible/roles/caldera_server/handlers/main.yml
+++ b/terraform/ansible/roles/caldera_server/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Enable Service [Caldera]
+  become: true
+  ansible.builtin.systemd_service:
+    state: restarted
+    enabled: true
+    daemon_reload: true
+    name: caldera.service
+  listen: caldera_systemd
+  when: caldera_server_skip_start == false

--- a/terraform/ansible/roles/caldera_server/tasks/caldera.yml
+++ b/terraform/ansible/roles/caldera_server/tasks/caldera.yml
@@ -1,0 +1,44 @@
+---
+- name: Clone from GitHub [Caldera]
+  ansible.builtin.shell: |
+    cd ~/
+    git clone https://github.com/mitre/caldera.git --recursive {{ caldera_server.caldera_version }}
+
+- name: Update URL [Caldera]
+  ansible.builtin.import_tasks: update_ip.yml
+  when: caldera_server_skip_start == false
+
+- name: Update Password [Caldera]
+  ansible.builtin.replace:
+    path: /home/admin/caldera/conf/default.yml
+    regexp: 'admin$'
+    replace: "{{ general.attack_range_password }}"
+
+- name: Update Agents [Caldera]
+  ansible.builtin.lineinfile:
+    path: /home/admin/caldera/conf/agents.yml
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  loop:
+    - { regexp: "sleep_max", line: 'sleep_max: 5' }
+    - { regexp: 'sleep_min', line: 'sleep_min: 2'}
+
+- name: Setup Server [Caldera]
+  ansible.builtin.shell: |
+    cd ~/caldera
+    reqs='/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin'
+    upx=$(find /usr/local/upx-* -type d)
+    nvm=$(find /home/admin/.nvm/versions/node/*/bin -type d)
+    echo "PATH=$reqs:$upx:$nvm" > caldera.env
+    pipenv install
+    pipenv run pip install -r requirements-dev.txt
+
+- name: Create Systemd service [Caldera]
+  become: true
+  ansible.builtin.copy:
+    src: caldera.service
+    dest: /etc/systemd/system/
+    owner: root
+    group: root
+    mode: '0644'
+  notify: caldera_systemd

--- a/terraform/ansible/roles/caldera_server/tasks/dependencies.yml
+++ b/terraform/ansible/roles/caldera_server/tasks/dependencies.yml
@@ -1,0 +1,12 @@
+---
+- name: Installing Dependencies [Caldera]
+  become: true
+  ansible.builtin.apt:
+    name:
+      - git
+      - curl
+      - wget
+      - pipenv
+      - lsof
+    update_cache: true
+    clean: true

--- a/terraform/ansible/roles/caldera_server/tasks/go.yml
+++ b/terraform/ansible/roles/caldera_server/tasks/go.yml
@@ -1,0 +1,9 @@
+---
+- name: Install GO [Caldera]
+  become: true
+  ansible.builtin.unarchive:
+    src: "https://go.dev/dl/go{{ caldera_server.go_version }}.linux-amd64.tar.gz"
+    dest: /usr/local
+    remote_src: true
+    owner: root
+    group: root

--- a/terraform/ansible/roles/caldera_server/tasks/hostname.yml
+++ b/terraform/ansible/roles/caldera_server/tasks/hostname.yml
@@ -1,0 +1,5 @@
+---
+- name: Change hostname [Caldera]
+  become: true
+  ansible.builtin.hostname:
+    name: "{{ caldera_server.hostname }}"

--- a/terraform/ansible/roles/caldera_server/tasks/main.yml
+++ b/terraform/ansible/roles/caldera_server/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Set Hostname [Caldera]
+  ansible.builtin.import_tasks: hostname.yml
+  when: caldera_server_action == "install"
+
+- name: Install dependencies [Caldera]
+  ansible.builtin.import_tasks: dependencies.yml
+  when: caldera_server_action == "install"
+
+- name: Install GO [Caldera]
+  ansible.builtin.import_tasks: go.yml
+  when: caldera_server_action == "install"
+
+- name: Install Node [Caldera]
+  ansible.builtin.import_tasks: node.yml
+  when: caldera_server_action == "install"
+
+- name: Install UPX [Caldera]
+  ansible.builtin.import_tasks: upx.yml
+  when: caldera_server_action == "install"
+
+- name: Update Path [Caldera]
+  ansible.builtin.import_tasks: path.yml
+  when: caldera_server_action == "install"
+
+- name: Install [Caldera]
+  ansible.builtin.import_tasks: caldera.yml
+  when: caldera_server_action == "install"
+
+- name: Update EIP [Caldera]
+  ansible.builtin.import_tasks: update_ip.yml
+  when: caldera_server_action == "update_eip"

--- a/terraform/ansible/roles/caldera_server/tasks/node.yml
+++ b/terraform/ansible/roles/caldera_server/tasks/node.yml
@@ -1,0 +1,11 @@
+---
+- name: Install NVM [Caldera]
+  ansible.builtin.shell: >
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v{{ caldera_server.nvm_version }}/install.sh | bash
+
+- name: Install NODE [Caldera]
+  ansible.builtin.shell: |
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+    nvm install {{ caldera_server.node_version }}

--- a/terraform/ansible/roles/caldera_server/tasks/path.yml
+++ b/terraform/ansible/roles/caldera_server/tasks/path.yml
@@ -1,0 +1,12 @@
+---
+- name: Update Path [Caldera]
+  ansible.builtin.blockinfile:
+    path: "/home/admin/.bashrc"
+    insertafter: EOF
+    append_newline: true
+    prepend_newline: true
+    block: |
+      export PATH="/usr/local/go/bin:/usr/local/upx-{{ caldera_server.upx_version }}-amd64_linux:$PATH"
+
+- name: Export PATH [Caldera]
+  ansible.builtin.shell: . ~/.bashrc

--- a/terraform/ansible/roles/caldera_server/tasks/update_ip.yml
+++ b/terraform/ansible/roles/caldera_server/tasks/update_ip.yml
@@ -1,0 +1,12 @@
+---
+- name: Update URL [Caldera]
+  ansible.builtin.lineinfile:
+    path: /home/admin/caldera/conf/default.yml
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  loop:
+    - { regexp: 'api_base_url', line: "app.frontend.api_base_url: http://{{ public_ip }}:8888" }
+    - { regexp: 'app\.contact\.http', line: "app.contact.http: http://{{ public_ip }}:8888" }
+    - { regexp: 'app\.contact\.tcp', line: "app.contact.tcp: {{ public_ip }}:7010" }
+    - { regexp: 'app\.contact\.udp', line: "app.contact.udp: {{ public_ip }}:7011" }
+  notify: caldera_systemd

--- a/terraform/ansible/roles/caldera_server/tasks/upx.yml
+++ b/terraform/ansible/roles/caldera_server/tasks/upx.yml
@@ -1,0 +1,9 @@
+---
+- name: Install UPX [Caldera]
+  become: true
+  ansible.builtin.unarchive:
+    src: "https://github.com/upx/upx/releases/download/v{{ caldera_server.upx_version }}/upx-{{ caldera_server.upx_version }}-amd64_linux.tar.xz"
+    dest: /usr/local
+    remote_src: true
+    owner: root
+    group: root

--- a/terraform/ansible/windows.yml
+++ b/terraform/ansible/windows.yml
@@ -23,3 +23,7 @@
     - crowdstrike_falcon_agent_win
     - carbon_black_cloud_agent_win
     - cisco_secure_endpoint_win
+    - role: caldera_agent
+      vars:
+        caldera_agent_server_type: "windows"
+      when: caldera_server.caldera_server == "1" and windows_servers.install_caldera_agent == "1"

--- a/terraform/aws/modules/caldera-server/resources.tf
+++ b/terraform/aws/modules/caldera-server/resources.tf
@@ -1,0 +1,110 @@
+
+data "aws_ami" "caldera_server" {
+  count       = var.caldera_server.caldera_server == "1" ? 1 : 0
+  most_recent = true
+  owners      = ["679593333241"] # owned by AWS marketplace
+
+  filter {
+      name   = "name"
+      values = ["debian-12-amd64-2024*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "caldera_server" {
+  count                  = var.caldera_server.caldera_server == "1" ? 1 : 0
+  ami                    = data.aws_ami.caldera_server[count.index].id
+  instance_type          = "m5.2xlarge"
+  key_name               = var.general.key_name
+  subnet_id              = var.ec2_subnet_id
+  vpc_security_group_ids = [var.vpc_security_group_ids]
+  private_ip             = var.caldera_server.private_ip
+  associate_public_ip_address = true
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = "60"
+    delete_on_termination = "true"
+  }
+
+  tags = {
+    Name = "ar-caldera-${var.general.key_name}-${var.general.attack_range_name}"
+  }
+
+  provisioner "remote-exec" {
+    inline = ["echo booted"]
+
+    connection {
+      type        = "ssh"
+      user        = "admin"
+      host        = self.public_ip
+      private_key = file(var.aws.private_key_path)
+    }
+  }
+
+  provisioner "local-exec" {
+    working_dir = "../ansible"
+    command = <<-EOT
+      cat <<EOF > vars/caldera_vars.json
+      {
+        "ansible_python_interpreter": "/usr/bin/python3",
+        "general": ${jsonencode(var.general)},
+        "aws": ${jsonencode(var.aws)},
+        "caldera_server": ${jsonencode(var.caldera_server)},
+        "public_ip": ${jsonencode(self.public_ip)},
+        "aws_eip": ${jsonencode(var.aws.use_elastic_ips)}
+      }
+      EOF
+    EOT
+  }
+
+  provisioner "local-exec" {
+    working_dir = "../ansible"
+    command = <<-EOT
+      ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u admin --private-key '${var.aws.private_key_path}' -i '${self.public_ip},' caldera_server.yml -e "@vars/caldera_vars.json"
+    EOT
+  }
+
+}
+
+resource "aws_eip" "caldera_ip" {
+  count    = (var.caldera_server.caldera_server == "1") && (var.aws.use_elastic_ips == "1") ? 1 : 0
+  instance = aws_instance.caldera_server[0].id
+
+  provisioner "remote-exec" {
+    inline = ["echo booted"]
+
+    connection {
+      type        = "ssh"
+      user        = "admin"
+      host        = self.public_ip
+      private_key = file(var.aws.private_key_path)
+    }
+  }
+
+  provisioner "local-exec" {
+    working_dir = "../ansible"
+    command = <<-EOT
+      cat <<EOF > vars/caldera_vars.json
+      {
+        "ansible_python_interpreter": "/usr/bin/python3",
+        "general": ${jsonencode(var.general)},
+        "aws": ${jsonencode(var.aws)},
+        "caldera_server": ${jsonencode(var.caldera_server)},
+        "public_ip": ${jsonencode(self.public_ip)}
+      }
+      EOF
+    EOT
+  }
+
+  provisioner "local-exec" {
+    working_dir = "../ansible"
+    command = <<-EOT
+      ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u admin --private-key '${var.aws.private_key_path}' -i '${self.public_ip},' caldera_eip.yml -e "@vars/caldera_vars.json"
+    EOT
+  }
+}

--- a/terraform/aws/modules/caldera-server/variable.tf
+++ b/terraform/aws/modules/caldera-server/variable.tf
@@ -1,0 +1,5 @@
+variable "vpc_security_group_ids" { }
+variable "ec2_subnet_id" { }
+variable "general" { }
+variable "caldera_server" { }
+variable "aws" { }

--- a/terraform/aws/modules/linux-server/resources.tf
+++ b/terraform/aws/modules/linux-server/resources.tf
@@ -57,6 +57,7 @@ resource "aws_instance" "linux_server" {
         "splunk_server": ${jsonencode(var.splunk_server)},
         "linux_servers": ${jsonencode(var.linux_servers[count.index])},
         "simulation": ${jsonencode(var.simulation)},
+        "caldera_server": ${jsonencode(var.caldera_server)},
       }
       EOF
     EOT

--- a/terraform/aws/modules/linux-server/variable.tf
+++ b/terraform/aws/modules/linux-server/variable.tf
@@ -8,3 +8,4 @@ variable "simulation" { }
 variable "splunk_server" { }
 variable "zeek_server" { }
 variable "snort_server" { }
+variable "caldera_server" { }

--- a/terraform/aws/modules/windows/resources.tf
+++ b/terraform/aws/modules/windows/resources.tf
@@ -88,6 +88,7 @@ EOF
         "splunk_server": ${jsonencode(var.splunk_server)},
         "simulation": ${jsonencode(var.simulation)},
         "windows_servers": ${jsonencode(var.windows_servers[count.index])},
+        "caldera_server": ${jsonencode(var.caldera_server)},
       }
       EOF
     EOT

--- a/terraform/aws/modules/windows/variables.tf
+++ b/terraform/aws/modules/windows/variables.tf
@@ -8,3 +8,4 @@ variable "splunk_server" { }
 variable "simulation" { }
 variable "zeek_server" { }
 variable "snort_server" { }
+variable "caldera_server" { }

--- a/terraform/aws/resources.tf
+++ b/terraform/aws/resources.tf
@@ -41,7 +41,8 @@ module "windows-server" {
   windows_servers = var.windows_servers
   simulation = var.simulation
   splunk_server = var.splunk_server
-  
+  caldera_server = var.caldera_server
+  # depends_on = [ module.caldera-server.caldera_servers ]
 }
 
 module "linux-server" {
@@ -55,6 +56,8 @@ module "linux-server" {
   linux_servers = var.linux_servers
   simulation = var.simulation
   splunk_server = var.splunk_server
+  caldera_server = var.caldera_server
+  # depends_on = [ module.caldera-server.caldera_servers ]
 }
 
 module "kali-server" {
@@ -102,4 +105,13 @@ module "snort-server" {
   linux_servers = var.linux_servers
   linux_server_instances = module.linux-server.linux_servers
   splunk_server = var.splunk_server
+}
+
+module "caldera-server" {
+  source = "./modules/caldera-server"
+	vpc_security_group_ids = module.networkModule.sg_vpc_id
+	ec2_subnet_id = module.networkModule.ec2_subnet_id
+  general = var.general
+  caldera_server = var.caldera_server
+  aws = var.aws
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -50,6 +50,7 @@ variable "windows_servers" {
         create_domain = "0"
         join_domain = "0"
         install_red_team_tools = "0"
+        install_caldera_agent = "0"
     }
   ]
 }
@@ -62,6 +63,7 @@ variable "linux_servers" {
         hostname = "ar-linux"
         image = "ubuntu-18-04-v2-0-0"
         sysmon_config = "configs/SwiftOnSecurity.xml"
+        install_caldera_agent = "0"
     }
   ]
 }
@@ -90,3 +92,11 @@ variable "nginx_server" {
 variable "zeek_server" { }
 
 variable "snort_server" { }
+
+variable "caldera_server" {
+    type = map(string)
+
+    default = {
+        "caldera_server" = "0"
+    }
+}


### PR DESCRIPTION
### In this pull-request

- Added MITRE Caldera
  - [MITRE Caldera](https://caldera.mitre.org/) is a scalable, automated adversary emulation platform. 

closes #1004 

#### How to Use

- Currently this is only supported in AWS.
- run `python attack_range.py configure` to enable the MITRE Caldera server and selectively allow where agents should be deployed.
- Refer to the [attack_range_default.yml](https://github.com/splunk/attack_range/blob/1c3162d985f9e9da8ae476b38e0bce18a21d5ed0/configs/attack_range_default.yml) config file for all options.