### PR TITLE
replay_file_path

### DIFF
--- a/modules/ansible/roles/data_replay/tasks/main.yml
+++ b/modules/ansible/roles/data_replay/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Upload replay
   copy:
-    src: ../../{{ file_name }}
+    src: "{{ file_name }}"
     dest: /tmp/data.log
 
 - name: Call oneshot import

--- a/modules/aws_controller.py
+++ b/modules/aws_controller.py
@@ -396,6 +396,10 @@ class AwsController(AttackRangeController):
         self.logger.info("[Completed]")
 
     def replay(self, file_name, index, sourcetype, source) -> None:
+        ### check if input log file is afile path or just a file name
+        ### if file name ,assume it is in current working dir of attack_range.py
+        if Path(file_name).parent == Path("."):
+            file_name = str(Path("../..")/file_name)
         ansible_vars = {}
         ansible_vars["file_name"] = file_name
         ansible_vars["ansible_user"] = "ubuntu"

--- a/modules/azure_controller.py
+++ b/modules/azure_controller.py
@@ -12,7 +12,7 @@ from modules import azure_service, splunk_sdk
 from modules.attack_range_controller import AttackRangeController
 from modules.art_simulation_controller import ArtSimulationController
 from modules.purplesharp_simulation_controller import PurplesharpSimulationController
-
+from pathlib import Path
 
 class AzureController(AttackRangeController):
 
@@ -287,6 +287,10 @@ class AzureController(AttackRangeController):
         self.logger.info("[Completed]")
 
     def replay(self, file_name, index, sourcetype, source) -> None:
+        ### check if input log file is afile path or just a file name
+        ### if file name ,assume it is in current working dir of attack_range.py
+        if Path(file_name).parent == Path("."):
+            file_name = str(Path("../..")/file_name)
         ansible_vars = {}
         ansible_vars["file_name"] = file_name
         ansible_vars["ansible_user"] = "ubuntu"


### PR DESCRIPTION
Currently you are only allow to replay the dataset logs from attack data if it is in attack range folder path. This minor enhancement allow the Splunk Attack Range users to replay attack data which file path is outside the attack range folder path. 