### PR TITLE
Fixed unassigned ip_address variable errors

### DIFF
--- a/modules/azure_controller.py
+++ b/modules/azure_controller.py
@@ -257,10 +257,9 @@ class AzureController(AttackRangeController):
                 )
                 instance_name = instance["vm_obj"].name
                 if instance_name.startswith("ar-splunk"):
-                    ip_address = instance["public_ip"]
                     messages.append(
                         "\nAccess Guacamole via:\n\tWeb > http://"
-                        + ip_address
+                        + instance["public_ip"]
                         + ":8080/guacamole"
                         + "\n\tusername: Admin \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
@@ -268,41 +267,41 @@ class AzureController(AttackRangeController):
                     if self.config["splunk_server"]["install_es"] == "1":
                         messages.append(
                             "\n\nAccess Splunk via:\n\tWeb > https://"
-                            + ip_address
+                            + instance["public_ip"]
                             + ":8000\n\tSSH > ssh -i"
                             + self.config["azure"]["private_key_path"]
                             + " ubuntu@"
-                            + ip_address
+                            + instance["public_ip"]
                             + "\n\tusername: admin \n\tpassword: "
                             + self.config["general"]["attack_range_password"]
                         )
                     else:
                         messages.append(
                             "\n\nAccess Splunk via:\n\tWeb > http://"
-                            + ip_address
+                            + instance["public_ip"]
                             + ":8000\n\tSSH > ssh -i"
                             + self.config["azure"]["private_key_path"]
                             + " ubuntu@"
-                            + ip_address
+                            + instance["public_ip"]
                             + "\n\tusername: admin \n\tpassword: "
                             + self.config["general"]["attack_range_password"]
                         )
                 elif instance_name.startswith("ar-phantom"):
                     messages.append(
                         "\nAccess Phantom via:\n\tWeb > https://"
-                        + ip_address
+                        + instance["public_ip"]
                         + ":8443"
                         + "\n\tSSH > ssh -i"
                         + self.config["azure"]["private_key_path"]
                         + " centos@"
-                        + ip_address
+                        + instance["public_ip"]
                         + "\n\tusername: soar_local_admin \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )
                 elif instance_name.startswith("ar-win"):
                     messages.append(
                         "\nAccess Windows via:\n\tRDP > rdp://"
-                        + ip_address
+                        + instance["public_ip"]
                         + ":3389\n\tusername: AzureAdmin \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )
@@ -311,7 +310,7 @@ class AzureController(AttackRangeController):
                         "\nAccess Linux via:\n\tSSH > ssh -i"
                         + self.config["azure"]["private_key_path"]
                         + " ubuntu@"
-                        + ip_address
+                        + instance["public_ip"]
                         + "\n\tusername: ubuntu \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )
@@ -320,7 +319,7 @@ class AzureController(AttackRangeController):
                         "\nAccess Kali via:\n\tSSH > ssh -i"
                         + self.config["azure"]["private_key_path"]
                         + " kali@"
-                        + ip_address
+                        + instance["public_ip"]
                         + "\n\tusername: kali \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )
@@ -329,7 +328,7 @@ class AzureController(AttackRangeController):
                         "\nAccess Nginx Web Proxy via:\n\tSSH > ssh -i"
                         + self.config["azure"]["private_key_path"]
                         + " ubuntu@"
-                        + ip_address
+                        + instance["public_ip"]
                         + "\n\tusername: kali \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )

--- a/modules/gcp_controller.py
+++ b/modules/gcp_controller.py
@@ -270,10 +270,9 @@ class GCPController(AttackRangeController):
                     [instance.name, instance.status, public_ip, str(instance.id)]
                 )
                 if instance.name.startswith("ar-splunk"):
-                    ip_address = public_ip
                     messages.append(
                         "\nAccess Guacamole via:\n\tWeb > http://"
-                        + ip_address
+                        + public_ip
                         + ":8080/guacamole"
                         + "\n\tusername: Admin \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
@@ -281,22 +280,22 @@ class GCPController(AttackRangeController):
                     if self.config["splunk_server"]["install_es"] == "1":
                         messages.append(
                             "\nAccess Splunk via:\n\tWeb > https://"
-                            + ip_address
+                            + public_ip
                             + ":8000\n\tSSH > ssh -i"
                             + self.config["gcp"]["private_key_path"]
                             + " ubuntu@"
-                            + ip_address
+                            + public_ip
                             + "\n\tusername: admin \n\tpassword: "
                             + self.config["general"]["attack_range_password"]
                         )
                     else:
                         messages.append(
                             "\nAccess Splunk via:\n\tWeb > http://"
-                            + ip_address
+                            + public_ip
                             + ":8000\n\tSSH > ssh -i"
                             + self.config["gcp"]["private_key_path"]
                             + " ubuntu@"
-                            + ip_address
+                            + public_ip
                             + "\n\tusername: admin \n\tpassword: "
                             + self.config["general"]["attack_range_password"]
                         )
@@ -307,31 +306,31 @@ class GCPController(AttackRangeController):
                     ):
                         messages.append(
                             "\nAccess Phantom via:\n\tWeb > https://"
-                            + ip_address
+                            + public_ip
                             + ":8443"
                             + "\n\tSSH > ssh -i"
                             + self.config["gcp"]["private_key_path"]
                             + " centos@"
-                            + ip_address
+                            + public_ip
                             + "\n\tusername: soar_local_admin \n\tpassword: "
                             + self.config["general"]["attack_range_password"]
                         )
                     else:
                         messages.append(
                             "\nAccess Phantom via:\n\tWeb > https://"
-                            + ip_address
+                            + public_ip
                             + ":8443"
                             + "\n\tSSH > ssh -i"
                             + self.config["gcp"]["private_key_path"]
                             + " centos@"
-                            + ip_address
+                            + public_ip
                             + "\n\tusername: admin \n\tpassword: "
                             + self.config["general"]["attack_range_password"]
                         )
                 elif instance.name.startswith("ar-win"):
                     messages.append(
                         "\nAccess Windows via:\n\tRDP > rdp://"
-                        + ip_address
+                        + public_ip
                         + ":3389\n\tusername: Administrator \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )
@@ -340,7 +339,7 @@ class GCPController(AttackRangeController):
                         "\nAccess Linux via:\n\tSSH > ssh -i"
                         + self.config["gcp"]["private_key_path"]
                         + " ubuntu@"
-                        + ip_address
+                        + public_ip
                         + "\n\tusername: ubuntu \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )
@@ -349,7 +348,7 @@ class GCPController(AttackRangeController):
                         "\nAccess Kali via:\n\tSSH > ssh -i"
                         + self.config["gcp"]["private_key_path"]
                         + " kali@"
-                        + ip_address
+                        + public_ip
                         + "\n\tusername: kali \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )
@@ -358,16 +357,16 @@ class GCPController(AttackRangeController):
                         "\nAccess Nginx Web Proxy via:\n\tSSH > ssh -i"
                         + self.config["gcp"]["private_key_path"]
                         + " ubuntu@"
-                        + ip_address
+                        + public_ip
                         + "\n\tWeb > http://"
-                        + ip_address
+                        + public_ip
                     )
                 elif instance.name.startswith("ar-zeek"):
                     messages.append(
                         "\nAccess Zeek via:\n\tSSH > ssh -i"
                         + self.config["gcp"]["private_key_path"]
                         + " ubuntu@"
-                        + ip_address
+                        + public_ip
                         + "\n\tusername: ubuntu \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )
@@ -376,7 +375,7 @@ class GCPController(AttackRangeController):
                         "\nAccess Snort via:\n\tSSH > ssh -i"
                         + self.config["gcp"]["private_key_path"]
                         + " ubuntu@"
-                        + ip_address
+                        + public_ip
                         + "\n\tusername: ubuntu \n\tpassword: "
                         + self.config["general"]["attack_range_password"]
                     )


### PR DESCRIPTION
This pull request is to fix issue #1263 

- Within gcp_controller.py the "public_ip" variable is already assigned correctly at the top of the for loop therefore the ip_address = public_ip is not required and public_ip can be used directly.
- Within azure_controller.py the "instance["public_ip"]" variable can be used directly similar to the aws approach.
