### PR TITLE
Disk size increased For Kali LInux and EBS type changed to gp3 #1340

### DIFF
--- a/terraform/aws/modules/caldera-server/resources.tf
+++ b/terraform/aws/modules/caldera-server/resources.tf
@@ -26,7 +26,7 @@ resource "aws_instance" "caldera_server" {
   associate_public_ip_address = true
 
   root_block_device {
-    volume_type = "gp2"
+    volume_type = "gp3"
     volume_size = "60"
     delete_on_termination = "true"
     encrypted  = "true"

--- a/terraform/aws/modules/kali-server/resources.tf
+++ b/terraform/aws/modules/kali-server/resources.tf
@@ -30,8 +30,8 @@ resource "aws_instance" "kali_machine" {
   }
 
   root_block_device {
-    volume_type = "gp2"
-    volume_size = "20"
+    volume_type = "gp3"
+    volume_size = "30"
     delete_on_termination = "true"
     encrypted  = "true"
   }

--- a/terraform/aws/modules/linux-server/resources.tf
+++ b/terraform/aws/modules/linux-server/resources.tf
@@ -27,7 +27,7 @@ resource "aws_instance" "linux_server" {
   associate_public_ip_address = true
 
   root_block_device {
-    volume_type = "gp2"
+    volume_type = "gp3"
     volume_size = "60"
     delete_on_termination = "true"
     encrypted  = "true"

--- a/terraform/aws/modules/nginx-server/resources.tf
+++ b/terraform/aws/modules/nginx-server/resources.tf
@@ -27,7 +27,7 @@ resource "aws_instance" "nginx_server" {
   associate_public_ip_address = true
   
   root_block_device {
-    volume_type = "gp2"
+    volume_type = "gp3"
     volume_size = "20"
     delete_on_termination = "true"
     encrypted  = "true"

--- a/terraform/aws/modules/phantom-server/resources.tf
+++ b/terraform/aws/modules/phantom-server/resources.tf
@@ -32,7 +32,7 @@ resource "aws_instance" "phantom-server" {
   private_ip             = "10.0.1.13"
   associate_public_ip_address = true
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = "30"
     delete_on_termination = "true"
     encrypted  = "true"

--- a/terraform/aws/modules/snort-server/resources.tf
+++ b/terraform/aws/modules/snort-server/resources.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "snort_sensor" {
   }
 
   root_block_device {
-    volume_type = "gp2"
+    volume_type = "gp3"
     volume_size = "20"
     delete_on_termination = "true"
     encrypted  = "true"

--- a/terraform/aws/modules/splunk-server/resources.tf
+++ b/terraform/aws/modules/splunk-server/resources.tf
@@ -85,7 +85,7 @@ resource "aws_instance" "splunk-server" {
   associate_public_ip_address = true
 
   root_block_device {
-    volume_type = "gp2"
+    volume_type = "gp3"
     volume_size = "120"
     delete_on_termination = "true"
     encrypted  = "true"

--- a/terraform/aws/modules/windows/resources.tf
+++ b/terraform/aws/modules/windows/resources.tf
@@ -68,6 +68,7 @@ Resize-Partition -DriveLetter $drive_letter -Size $size.SizeMax
 EOF
 
   root_block_device {
+    volume_type           = "gp3"
     delete_on_termination = true
     volume_size           = 50
     encrypted  = "true"

--- a/terraform/aws/modules/zeek-server/resources.tf
+++ b/terraform/aws/modules/zeek-server/resources.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "zeek_sensor" {
   }
 
   root_block_device {
-    volume_type = "gp2"
+    volume_type = "gp3"
     volume_size = "20"
     delete_on_termination = "true"
     encrypted  = "true"


### PR DESCRIPTION
Fix for https://github.com/splunk/attack_range/issues/1340

I have increased Kali linux EBS to 30 GB and updated all EBS types to gp3. Generally gp3 is cheaper and better for most of the cases, including this one. If there is a need I could move it to variables so if someone has infra provisioned on gp2 can still stick with it.