### PR TITLE
Added tests for aws provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ name = "pypi-public"
 url = "https://pypi.org/simple/"
 
 [tool.poetry.dev-dependencies]
+pytest = "^8.0"
+moto = {version = "^5.0", extras = ["s3"]}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,83 @@
+import logging
+import os
+import pytest
+
+
+@pytest.fixture
+def aws_credentials():
+    """Mock AWS credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
+
+
+@pytest.fixture
+def mock_logger():
+    """Create a logger for testing."""
+    logger = logging.getLogger("test_attack_range")
+    logger.setLevel(logging.DEBUG)
+    return logger
+
+
+@pytest.fixture
+def aws_config():
+    """Sample AWS config for testing."""
+    return {
+        "general": {
+            "cloud_provider": "aws",
+            "attack_range_id": "test-range-123",
+        },
+        "aws": {
+            "region": "us-west-2",
+        },
+        "attack_range": [],
+    }
+
+
+@pytest.fixture
+def aws_config_us_east_1():
+    """Sample AWS config for us-east-1 region testing."""
+    return {
+        "general": {
+            "cloud_provider": "aws",
+            "attack_range_id": "test-range-123",
+        },
+        "aws": {
+            "region": "us-east-1",
+        },
+        "attack_range": [],
+    }
+
+
+@pytest.fixture
+def aws_backend_context(aws_credentials, aws_config, mock_logger, tmp_path):
+    """Create an AWS provider + backend manager test context."""
+    # Keep provider/manager imports lazy so test-only module mocks can be applied first.
+    import sys
+    from unittest.mock import MagicMock
+
+    sys.modules["ansible_runner"] = MagicMock()
+    sys.modules["python_vagrant"] = MagicMock()
+
+    from attack_range.cloud_providers.aws_provider import AWSProvider
+    from attack_range.managers.backend_manager import BackendManager
+
+    provider = AWSProvider(aws_config, mock_logger)
+    manager = BackendManager(
+        terraform_dir=str(tmp_path),
+        config=aws_config,
+        config_path=str(tmp_path / "config.yml"),
+        cloud_provider=provider,
+        logger=mock_logger,
+    )
+    backend_name = "terraform-state-test-range-123"
+    return {
+        "provider": provider,
+        "manager": manager,
+        "region": "us-west-2",
+        "bucket_name": provider.sanitize_name(backend_name),
+        "table_name": provider.sanitize_name(backend_name),
+        "tmp_path": tmp_path,
+    }

--- a/tests/test_aws_provider.py
+++ b/tests/test_aws_provider.py
@@ -1,0 +1,95 @@
+"""
+Smoke tests for AWS BackendManager.
+
+Tests setup_remote_backend and cleanup_remote_backend using moto to mock AWS.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+sys.modules["ansible_runner"] = MagicMock()
+sys.modules["python_vagrant"] = MagicMock()
+
+import boto3
+import pytest
+from moto import mock_aws
+
+
+class TestBackendManagerSmoke:
+    """
+    Smoke tests for BackendManager with AWS provider.
+
+    Tests the full lifecycle: setup_remote_backend creates S3 bucket
+    cleanup_remote_backend removes them.
+    """
+
+    @mock_aws
+    def test_setup_remote_backend_creates_s3_bucket(self, aws_backend_context):
+        """Setup remote backend should create S3 bucket when it doesn't exist."""
+        provider = aws_backend_context["provider"]
+        manager = aws_backend_context["manager"]
+
+        backend_was_created = manager.setup_remote_backend()
+
+        assert backend_was_created is True
+        bucket_name = aws_backend_context["bucket_name"]
+        s3_client = boto3.client("s3", region_name=aws_backend_context["region"])
+        response = s3_client.head_bucket(Bucket=bucket_name)
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+    @mock_aws
+    def test_setup_remote_backend_writes_backend_tf(self, aws_backend_context):
+        """Setup remote backend should write backend.tf configuration file."""
+        manager = aws_backend_context["manager"]
+
+        manager.setup_remote_backend()
+
+        backend_tf_path = aws_backend_context["tmp_path"] / "backend.tf"
+        assert backend_tf_path.exists()
+        content = backend_tf_path.read_text()
+        assert 'backend "s3"' in content
+        assert "terraform-state-test-range-123" in content
+
+    @mock_aws
+    def test_setup_remote_backend_idempotent(self, aws_backend_context):
+        """Setup remote backend should return False if resources already exist."""
+        manager = aws_backend_context["manager"]
+
+        first_call = manager.setup_remote_backend()
+        second_call = manager.setup_remote_backend()
+
+        assert first_call is True
+        assert second_call is False
+
+    @mock_aws
+    def test_cleanup_remote_backend_deletes_s3_bucket(self, aws_backend_context):
+        """Cleanup remote backend should delete S3 bucket."""
+        provider = aws_backend_context["provider"]
+        manager = aws_backend_context["manager"]
+
+        manager.setup_remote_backend()
+        manager.cleanup_remote_backend()
+
+        bucket_name = aws_backend_context["bucket_name"]
+        assert provider.check_s3_bucket(bucket_name, aws_backend_context["region"]) is False
+
+    @mock_aws
+    def test_full_lifecycle_setup_and_cleanup(self, aws_backend_context):
+        """
+        Full smoke test: setup creates resources, cleanup removes them.
+
+        This simulates the build -> destroy flow.
+        """
+        provider = aws_backend_context["provider"]
+        manager = aws_backend_context["manager"]
+        bucket_name = aws_backend_context["bucket_name"]
+        table_name = aws_backend_context["table_name"]
+        region = aws_backend_context["region"]
+
+        backend_created = manager.setup_remote_backend()
+        assert backend_created is True
+        assert provider.check_s3_bucket(bucket_name, region) is True
+
+        manager.cleanup_remote_backend()
+        assert provider.check_s3_bucket(bucket_name, region) is False


### PR DESCRIPTION
Moto is amazing library which can easily mock aws. 

With this PR I have prepared tests for aws provider which checks if  `setup_remote_backend` creates s3 bucket and `cleanup_remote_backend` removes it for aws provider.

Having this test will allow easily detect if backend setup/cleanup works, unfortunately I dont think Azure and GCP have good equivalent to **moto**. IMO having 1 test is better than having zero.

Let me know what you think :)