### PR TITLE
Feat/proper cloud provider polymorhism and dataclass for Backend params

### DIFF
--- a/attack_range/ARCHITECTURE.md
+++ b/attack_range/ARCHITECTURE.md
@@ -105,7 +105,8 @@ Abstract base class defining the contract for all cloud providers:
 - `delete_backend()`: Delete backend storage
 - `import_ssh_key()`: Import SSH key (if applicable)
 - `delete_ssh_key()`: Delete SSH key (if applicable)
-- `update_backend_config()`: Update backend configuration file
+- `write_backend_config()`: Create/update backend configuration file
+- `get_backend_params()`: Get backend parameters for the current provider
 
 #### AWSProvider (`cloud_providers/aws_provider.py`)
 **Responsibility**: AWS-specific operations

--- a/attack_range/cloud_providers/aws_provider.py
+++ b/attack_range/cloud_providers/aws_provider.py
@@ -12,7 +12,7 @@ from botocore.exceptions import ClientError
 from typing import Optional
 import os
 
-from .base_provider import BaseCloudProvider
+from .base_provider import BaseCloudProvider, BackendParams
 
 
 class AWSProvider(BaseCloudProvider):
@@ -308,17 +308,17 @@ class AWSProvider(BaseCloudProvider):
         except Exception as e:
             self.logger.warning(f"Failed to delete key pair '{key_name}': {e}")
 
-    def update_backend_config(self, backend_params: dict, backend_file_path: str) -> None:
+    def write_backend_config(self, backend_params: BackendParams, backend_file_path: str) -> None:
         """
         Update or create backend.tf file with S3 backend configuration.
 
-        :param backend_params: Dictionary containing backend parameters
+        :param backend_params: Backend parameters
         :param backend_file_path: Path to the backend.tf file
         """
-        bucket_name = backend_params['bucket_name']
-        region = backend_params['region']
-        attack_range_id = backend_params.get('attack_range_id', 'unknown')
-        config_source = backend_params.get('config_source', 'template/config file')
+        bucket_name = backend_params.aws_bucket_name
+        region = backend_params.region
+        attack_range_id = backend_params.attack_range_id or 'unknown'
+        config_source = backend_params.config_source or 'template/config file'
 
         backend_config = f'''# This file is AUTO-GENERATED based on the template/config file.
 # DO NOT EDIT MANUALLY - changes will be overwritten.
@@ -346,22 +346,22 @@ terraform {{
 
         self.logger.info(f"Backend configuration written to {backend_file_path} (generated from {config_source})")
 
-    def get_backend_params(self, attack_range_id: str, config_source: str = "template/config file") -> dict:
+    def get_backend_params(self, attack_range_id: str, config_source: str = "template/config file") -> BackendParams:
         """
         Get backend parameters for AWS (S3 bucket).
 
         :param attack_range_id: The attack range ID for naming
         :param config_source: Source config file name for backend.tf comments
-        :return: Dictionary with backend parameters
+        :return: Backend parameters
         """
         backend_name = f"terraform-state-{attack_range_id}"
         bucket_name = self.sanitize_name(backend_name)
         region = self.get_region(required=True)
 
-        return {
-            'backend_name': backend_name,
-            'bucket_name': bucket_name,
-            'region': region,
-            'attack_range_id': attack_range_id,
-            'config_source': config_source
-        }
+        return BackendParams(
+            backend_name=backend_name,
+            aws_bucket_name=bucket_name,
+            region=region,
+            attack_range_id=attack_range_id,
+            config_source=config_source
+        )

--- a/attack_range/cloud_providers/aws_provider.py
+++ b/attack_range/cloud_providers/aws_provider.py
@@ -345,3 +345,23 @@ terraform {{
             f.write(backend_config)
 
         self.logger.info(f"Backend configuration written to {backend_file_path} (generated from {config_source})")
+
+    def get_backend_params(self, attack_range_id: str, config_source: str = "template/config file") -> dict:
+        """
+        Get backend parameters for AWS (S3 bucket).
+
+        :param attack_range_id: The attack range ID for naming
+        :param config_source: Source config file name for backend.tf comments
+        :return: Dictionary with backend parameters
+        """
+        backend_name = f"terraform-state-{attack_range_id}"
+        bucket_name = self.sanitize_name(backend_name)
+        region = self.get_region(required=True)
+
+        return {
+            'backend_name': backend_name,
+            'bucket_name': bucket_name,
+            'region': region,
+            'attack_range_id': attack_range_id,
+            'config_source': config_source
+        }

--- a/attack_range/cloud_providers/azure_provider.py
+++ b/attack_range/cloud_providers/azure_provider.py
@@ -383,3 +383,28 @@ terraform {{
             f.write(backend_config)
 
         self.logger.info(f"Backend configuration written to {backend_file_path} (generated from {config_source})")
+
+    def get_backend_params(self, attack_range_id: str, config_source: str = "template/config file") -> dict:
+        """
+        Get backend parameters for Azure (Storage Account + Container).
+
+        :param attack_range_id: The attack range ID for naming
+        :param config_source: Source config file name for backend.tf comments
+        :return: Dictionary with backend parameters
+        """
+        backend_name = f"terraformstate{attack_range_id.replace('-', '')}"
+        storage_account_name = self.sanitize_name(backend_name)
+        container_name = "tfstate"
+        resource_group_name = f"rg-terraform-state-{attack_range_id}"
+        location = self.get_region(required=True)
+
+        return {
+            'backend_name': backend_name,
+            'storage_account_name': storage_account_name,
+            'container_name': container_name,
+            'resource_group_name': resource_group_name,
+            'location': location,
+            'region': location,
+            'attack_range_id': attack_range_id,
+            'config_source': config_source
+        }

--- a/attack_range/cloud_providers/azure_provider.py
+++ b/attack_range/cloud_providers/azure_provider.py
@@ -10,7 +10,7 @@ import re
 from typing import Optional
 import os
 
-from .base_provider import BaseCloudProvider
+from .base_provider import BaseCloudProvider, BackendParams
 
 # Azure imports
 try:
@@ -343,19 +343,19 @@ class AzureProvider(BaseCloudProvider):
         """
         self.logger.info("Azure: No cloud service keys to delete")
 
-    def update_backend_config(self, backend_params: dict, backend_file_path: str) -> None:
+    def write_backend_config(self, backend_params: BackendParams, backend_file_path: str) -> None:
         """
         Update or create backend.tf file with Azure backend configuration.
 
-        :param backend_params: Dictionary containing backend parameters
+        :param backend_params: Backend parameters
         :param backend_file_path: Path to the backend.tf file
         """
-        storage_account_name = backend_params['storage_account_name']
-        container_name = backend_params['container_name']
-        resource_group_name = backend_params['resource_group_name']
-        location = backend_params['location']
-        attack_range_id = backend_params.get('attack_range_id', 'unknown')
-        config_source = backend_params.get('config_source', 'template/config file')
+        storage_account_name = backend_params.azure_storage_account_name
+        container_name = backend_params.azure_container_name
+        resource_group_name = backend_params.azure_resource_group_name
+        location = backend_params.azure_location or backend_params.region
+        attack_range_id = backend_params.attack_range_id or 'unknown'
+        config_source = backend_params.config_source or 'template/config file'
 
         backend_config = f'''# This file is AUTO-GENERATED based on the template/config file.
 # DO NOT EDIT MANUALLY - changes will be overwritten.
@@ -384,13 +384,13 @@ terraform {{
 
         self.logger.info(f"Backend configuration written to {backend_file_path} (generated from {config_source})")
 
-    def get_backend_params(self, attack_range_id: str, config_source: str = "template/config file") -> dict:
+    def get_backend_params(self, attack_range_id: str, config_source: str = "template/config file") -> BackendParams:
         """
         Get backend parameters for Azure (Storage Account + Container).
 
         :param attack_range_id: The attack range ID for naming
         :param config_source: Source config file name for backend.tf comments
-        :return: Dictionary with backend parameters
+        :return: Backend parameters
         """
         backend_name = f"terraformstate{attack_range_id.replace('-', '')}"
         storage_account_name = self.sanitize_name(backend_name)
@@ -398,13 +398,13 @@ terraform {{
         resource_group_name = f"rg-terraform-state-{attack_range_id}"
         location = self.get_region(required=True)
 
-        return {
-            'backend_name': backend_name,
-            'storage_account_name': storage_account_name,
-            'container_name': container_name,
-            'resource_group_name': resource_group_name,
-            'location': location,
-            'region': location,
-            'attack_range_id': attack_range_id,
-            'config_source': config_source
-        }
+        return BackendParams(
+            backend_name=backend_name,
+            azure_storage_account_name=storage_account_name,
+            azure_container_name=container_name,
+            azure_resource_group_name=resource_group_name,
+            azure_location=location,
+            region=location,
+            attack_range_id=attack_range_id,
+            config_source=config_source
+        )

--- a/attack_range/cloud_providers/base_provider.py
+++ b/attack_range/cloud_providers/base_provider.py
@@ -5,8 +5,26 @@ This module defines the abstract base class for all cloud providers.
 """
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Optional
 import logging
+
+
+@dataclass
+class BackendParams:
+    """Shared backend parameters for all cloud providers."""
+
+    backend_name: str
+    region: str
+    attack_range_id: str
+    config_source: str = "template/config file"
+    aws_bucket_name: Optional[str] = None
+    gcp_bucket_name: Optional[str] = None
+    gcp_project_id: Optional[str] = None
+    azure_storage_account_name: Optional[str] = None
+    azure_container_name: Optional[str] = None
+    azure_resource_group_name: Optional[str] = None
+    azure_location: Optional[str] = None
 
 
 class BaseCloudProvider(ABC):
@@ -94,11 +112,27 @@ class BaseCloudProvider(ABC):
         pass
 
     @abstractmethod
-    def update_backend_config(self, backend_params: dict, backend_file_path: str) -> None:
+    def write_backend_config(self, backend_params: BackendParams, backend_file_path: str) -> None:
         """
-        Update the backend configuration file.
+        Save on disk the backend configuration file.
 
-        :param backend_params: Dictionary containing backend parameters
+        :param backend_params: Backend parameters for the current provider
         :param backend_file_path: Path to the backend.tf file
+        """
+        pass
+
+    @abstractmethod
+    def get_backend_params(self, attack_range_id: str, config_source: str = "template/config file") -> BackendParams:
+        """
+        Get backend parameters for the current provider.
+
+        Returns backend parameters with all information needed for backend setup:
+        - backend_name: Sanitized name for the storage resource
+        - region: Provider-specific region/location
+        - All provider-specific parameters needed for write_backend_config()
+
+        :param attack_range_id: The attack range ID for naming
+        :param config_source: Source config file name for backend.tf comments
+        :return: Backend parameters
         """
         pass

--- a/attack_range/cloud_providers/gcp_provider.py
+++ b/attack_range/cloud_providers/gcp_provider.py
@@ -265,3 +265,25 @@ terraform {{
             f.write(backend_config)
 
         self.logger.info(f"Backend configuration written to {backend_file_path} (generated from {config_source})")
+
+    def get_backend_params(self, attack_range_id: str, config_source: str = "template/config file") -> dict:
+        """
+        Get backend parameters for GCP (GCS bucket).
+
+        :param attack_range_id: The attack range ID for naming
+        :param config_source: Source config file name for backend.tf comments
+        :return: Dictionary with backend parameters
+        """
+        backend_name = f"terraform-state-{attack_range_id}"
+        bucket_name = self.sanitize_name(backend_name)
+        project_id = self.get_project_id(required=True)
+        region = self.get_region(required=True)
+
+        return {
+            'backend_name': backend_name,
+            'bucket_name': bucket_name,
+            'project_id': project_id,
+            'region': region,
+            'attack_range_id': attack_range_id,
+            'config_source': config_source
+        }

--- a/attack_range/cloud_providers/gcp_provider.py
+++ b/attack_range/cloud_providers/gcp_provider.py
@@ -9,7 +9,7 @@ import re
 from typing import Optional
 import os
 
-from .base_provider import BaseCloudProvider
+from .base_provider import BaseCloudProvider, BackendParams
 
 # GCP imports
 try:
@@ -231,17 +231,17 @@ class GCPProvider(BaseCloudProvider):
         """
         self.logger.info("GCP: No cloud service keys to delete")
 
-    def update_backend_config(self, backend_params: dict, backend_file_path: str) -> None:
+    def write_backend_config(self, backend_params: BackendParams, backend_file_path: str) -> None:
         """
         Update or create backend.tf file with GCP backend configuration.
 
-        :param backend_params: Dictionary containing backend parameters
+        :param backend_params: Backend parameters
         :param backend_file_path: Path to the backend.tf file
         """
-        bucket_name = backend_params['bucket_name']
-        project_id = backend_params['project_id']
-        attack_range_id = backend_params.get('attack_range_id', 'unknown')
-        config_source = backend_params.get('config_source', 'template/config file')
+        bucket_name = backend_params.gcp_bucket_name
+        project_id = backend_params.gcp_project_id
+        attack_range_id = backend_params.attack_range_id or 'unknown'
+        config_source = backend_params.config_source or 'template/config file'
 
         backend_config = f'''# This file is AUTO-GENERATED based on the template/config file.
 # DO NOT EDIT MANUALLY - changes will be overwritten.
@@ -266,24 +266,24 @@ terraform {{
 
         self.logger.info(f"Backend configuration written to {backend_file_path} (generated from {config_source})")
 
-    def get_backend_params(self, attack_range_id: str, config_source: str = "template/config file") -> dict:
+    def get_backend_params(self, attack_range_id: str, config_source: str = "template/config file") -> BackendParams:
         """
         Get backend parameters for GCP (GCS bucket).
 
         :param attack_range_id: The attack range ID for naming
         :param config_source: Source config file name for backend.tf comments
-        :return: Dictionary with backend parameters
+        :return: Backend parameters
         """
         backend_name = f"terraform-state-{attack_range_id}"
         bucket_name = self.sanitize_name(backend_name)
         project_id = self.get_project_id(required=True)
         region = self.get_region(required=True)
 
-        return {
-            'backend_name': backend_name,
-            'bucket_name': bucket_name,
-            'project_id': project_id,
-            'region': region,
-            'attack_range_id': attack_range_id,
-            'config_source': config_source
-        }
+        return BackendParams(
+            backend_name=backend_name,
+            gcp_bucket_name=bucket_name,
+            gcp_project_id=project_id,
+            region=region,
+            attack_range_id=attack_range_id,
+            config_source=config_source
+        )

--- a/attack_range/managers/backend_manager.py
+++ b/attack_range/managers/backend_manager.py
@@ -8,7 +8,6 @@ of cloud storage resources for state management.
 import os
 import sys
 import logging
-from typing import Tuple
 
 
 class BackendManager:
@@ -29,15 +28,11 @@ class BackendManager:
         self.config_path = config_path
         self.cloud_provider = cloud_provider
         self.logger = logger
-        self.cloud_provider_name = config.get("general", {}).get("cloud_provider", "aws").lower()
 
     def setup_remote_backend(self) -> bool:
         """
         Check if remote backend exists, otherwise create it.
-        For AWS: S3 bucket (with S3 native locking)
-        For Azure: Storage Account + Container
-        For GCP: GCS bucket
-        Uses attack_range_id for naming the backend resources.
+        Uses the cloud provider's polymorphic methods for backend operations.
 
         Returns:
             bool: True if backend resources were just created (fresh setup), False if they already existed
@@ -47,205 +42,48 @@ class BackendManager:
             self.logger.error("attack_range_id not found in config. Cannot setup remote backend.")
             sys.exit(1)
 
+        config_source = "template/config file"
+        if self.config_path:
+            config_source = os.path.basename(self.config_path)
+
+        backend_params = self.cloud_provider.get_backend_params(attack_range_id, config_source)
+        backend_name = backend_params["backend_name"]
+        region = backend_params["region"]
+
+        self.logger.info(f"Setting up remote backend: {backend_name}")
+
         backend_was_created = False
+        if not self.cloud_provider.check_backend_exists(backend_name):
+            self.logger.info(f"Backend '{backend_name}' does not exist. Creating it...")
+            self.cloud_provider.create_backend(backend_name, region)
+            backend_was_created = True
+        else:
+            self.logger.info(f"Backend '{backend_name}' already exists")
 
-        if self.cloud_provider_name == "gcp":
-            backend_name = f"terraform-state-{attack_range_id}"
-            bucket_name = self.cloud_provider.sanitize_name(backend_name)
-            project_id = self.cloud_provider.get_project_id(required=True)
-            region = self.cloud_provider.get_region(required=True)
+        backend_tf_path = os.path.join(self.terraform_dir, "backend.tf")
+        self.cloud_provider.update_backend_config(backend_params, backend_tf_path)
 
-            self.logger.info(f"Setting up GCP remote backend: bucket={bucket_name}")
-
-            # Check and create GCS bucket if needed
-            if not self.cloud_provider.check_gcs_bucket(bucket_name, project_id):
-                self.logger.info(f"GCS bucket '{bucket_name}' does not exist. Creating it...")
-                self.cloud_provider.create_gcs_bucket(bucket_name, project_id, region)
-                backend_was_created = True
-            else:
-                self.logger.info(f"GCS bucket '{bucket_name}' already exists")
-
-            # Update backend configuration in backend.tf
-            self._update_backend_config_gcp(bucket_name, project_id, attack_range_id)
-
-            self.logger.info("GCP remote backend setup completed successfully")
-            return backend_was_created
-
-        elif self.cloud_provider_name == "azure":
-            backend_name = f"terraformstate{attack_range_id.replace('-', '')}"
-            storage_account_name = self.cloud_provider.sanitize_name(backend_name)
-            container_name = "tfstate"
-            resource_group_name = f"rg-terraform-state-{attack_range_id}"
-            location = self.cloud_provider.get_region(required=True)
-
-            self.logger.info(f"Setting up Azure remote backend: storage_account={storage_account_name}, container={container_name}")
-
-            # Check and create storage account if needed
-            if not self.cloud_provider.check_storage_account(storage_account_name, resource_group_name):
-                self.logger.info(f"Azure Storage Account '{storage_account_name}' does not exist. Creating it...")
-                self.cloud_provider.create_storage_account(storage_account_name, resource_group_name, location)
-                backend_was_created = True
-            else:
-                self.logger.info(f"Azure Storage Account '{storage_account_name}' already exists")
-
-            # Check and create container if needed
-            if not self.cloud_provider.check_storage_container(storage_account_name, container_name, resource_group_name):
-                self.logger.info(f"Azure Storage Container '{container_name}' does not exist. Creating it...")
-                self.cloud_provider.create_storage_container(storage_account_name, container_name, resource_group_name)
-                backend_was_created = True
-            else:
-                self.logger.info(f"Azure Storage Container '{container_name}' already exists")
-
-            # Update backend configuration in backend.tf
-            self._update_backend_config_azure(storage_account_name, container_name, resource_group_name, location, attack_range_id)
-
-            self.logger.info("Azure remote backend setup completed successfully")
-            return backend_was_created
-
-        else:  # aws
-            backend_name = f"terraform-state-{attack_range_id}"
-            bucket_name = self.cloud_provider.sanitize_name(backend_name)
-            region = self.cloud_provider.get_region(required=True)
-
-            self.logger.info(f"Setting up remote backend: bucket={bucket_name}")
-
-            # Check and create S3 bucket if needed
-            if not self.cloud_provider.check_s3_bucket(bucket_name, region):
-                self.logger.info(f"S3 bucket '{bucket_name}' does not exist. Creating it...")
-                self.cloud_provider.create_s3_bucket(bucket_name, region)
-                backend_was_created = True
-            else:
-                self.logger.info(f"S3 bucket '{bucket_name}' already exists")
-
-            # Update backend configuration in backend.tf
-            self._update_backend_config_aws(bucket_name, region, attack_range_id)
-
-            self.logger.info("Remote backend setup completed successfully")
-            return backend_was_created
+        self.logger.info("Remote backend setup completed successfully")
+        return backend_was_created
 
     def cleanup_remote_backend(self) -> None:
         """
-        Clean up remote backend resources (S3 bucket for AWS,
-        Storage Account for Azure, GCS bucket for GCP).
-        Uses attack_range_id for naming the backend resources.
+        Clean up remote backend resources.
+        Uses the cloud provider's polymorphic delete_backend method.
         """
         attack_range_id = self.config.get("general", {}).get("attack_range_id")
         if not attack_range_id:
             self.logger.warning("attack_range_id not found in config. Cannot cleanup remote backend.")
             return
 
-        if self.cloud_provider_name == "gcp":
-            backend_name = f"terraform-state-{attack_range_id}"
-            bucket_name = self.cloud_provider.sanitize_name(backend_name)
-            project_id = self.cloud_provider.get_project_id(required=False)
-
-            if not project_id:
-                self.logger.warning("GCP project_id not found in config. Cannot cleanup remote backend.")
-                return
-
-            self.logger.info(f"Cleaning up GCP remote backend: bucket={bucket_name}")
-            self.cloud_provider.delete_gcs_bucket(bucket_name, project_id)
-            self.logger.info("GCP remote backend cleanup completed successfully")
-
-        elif self.cloud_provider_name == "azure":
-            backend_name = f"terraformstate{attack_range_id.replace('-', '')}"
-            storage_account_name = self.cloud_provider.sanitize_name(backend_name)
-            resource_group_name = f"rg-terraform-state-{attack_range_id}"
-            location = self.cloud_provider.get_region(required=False)
-
-            if not location:
-                self.logger.warning("Azure location not found in config. Cannot cleanup remote backend.")
-                return
-
-            self.logger.info(f"Cleaning up Azure remote backend: storage_account={storage_account_name}")
-            self.cloud_provider.delete_backend(backend_name, location)
-            self.logger.info("Azure remote backend cleanup completed successfully")
-
-        else:  # aws
-            backend_name = f"terraform-state-{attack_range_id}"
-            bucket_name = self.cloud_provider.sanitize_name(backend_name)
-            region = self.cloud_provider.get_region(required=False)
-
-            if not region:
-                self.logger.warning("AWS region not found in config. Cannot cleanup remote backend.")
-                return
-
-            self.logger.info(f"Cleaning up remote backend: bucket={bucket_name}")
-            self.cloud_provider.delete_s3_bucket(bucket_name, region)
-            self.logger.info("Remote backend cleanup completed successfully")
-
-    def _update_backend_config_aws(self, bucket_name: str, region: str, attack_range_id: str) -> None:
-        """
-        Update or create backend.tf file with S3 backend configuration.
-
-        :param bucket_name: Name of the S3 bucket for state storage
-        :param region: AWS region
-        :param attack_range_id: Attack range ID
-        """
-        backend_tf_path = os.path.join(self.terraform_dir, "backend.tf")
-
-        # Build comment header with config file info if available
         config_source = "template/config file"
         if self.config_path:
             config_source = os.path.basename(self.config_path)
 
-        backend_params = {
-            'bucket_name': bucket_name,
-            'region': region,
-            'attack_range_id': attack_range_id,
-            'config_source': config_source
-        }
+        backend_params = self.cloud_provider.get_backend_params(attack_range_id, config_source)
+        backend_name = backend_params["backend_name"]
+        region = backend_params["region"]
 
-        self.cloud_provider.update_backend_config(backend_params, backend_tf_path)
-
-    def _update_backend_config_azure(self, storage_account_name: str, container_name: str, resource_group_name: str, location: str, attack_range_id: str) -> None:
-        """
-        Update or create backend.tf file with Azure backend configuration.
-
-        :param storage_account_name: Name of the Azure Storage Account for state storage
-        :param container_name: Name of the Azure Storage Container
-        :param resource_group_name: Name of the resource group
-        :param location: Azure location
-        :param attack_range_id: Attack range ID
-        """
-        backend_tf_path = os.path.join(self.terraform_dir, "backend.tf")
-
-        # Build comment header with config file info if available
-        config_source = "template/config file"
-        if self.config_path:
-            config_source = os.path.basename(self.config_path)
-
-        backend_params = {
-            'storage_account_name': storage_account_name,
-            'container_name': container_name,
-            'resource_group_name': resource_group_name,
-            'location': location,
-            'attack_range_id': attack_range_id,
-            'config_source': config_source
-        }
-
-        self.cloud_provider.update_backend_config(backend_params, backend_tf_path)
-
-    def _update_backend_config_gcp(self, bucket_name: str, project_id: str, attack_range_id: str) -> None:
-        """
-        Update or create backend.tf file with GCP backend configuration.
-
-        :param bucket_name: Name of the GCS bucket for state storage
-        :param project_id: GCP project ID
-        :param attack_range_id: Attack range ID
-        """
-        backend_tf_path = os.path.join(self.terraform_dir, "backend.tf")
-
-        # Build comment header with config file info if available
-        config_source = "template/config file"
-        if self.config_path:
-            config_source = os.path.basename(self.config_path)
-
-        backend_params = {
-            'bucket_name': bucket_name,
-            'project_id': project_id,
-            'attack_range_id': attack_range_id,
-            'config_source': config_source
-        }
-
-        self.cloud_provider.update_backend_config(backend_params, backend_tf_path)
+        self.logger.info(f"Cleaning up remote backend: {backend_name}")
+        self.cloud_provider.delete_backend(backend_name, region)
+        self.logger.info("Remote backend cleanup completed successfully")

--- a/attack_range/managers/backend_manager.py
+++ b/attack_range/managers/backend_manager.py
@@ -47,8 +47,8 @@ class BackendManager:
             config_source = os.path.basename(self.config_path)
 
         backend_params = self.cloud_provider.get_backend_params(attack_range_id, config_source)
-        backend_name = backend_params["backend_name"]
-        region = backend_params["region"]
+        backend_name = backend_params.backend_name
+        region = backend_params.region
 
         self.logger.info(f"Setting up remote backend: {backend_name}")
 
@@ -61,7 +61,7 @@ class BackendManager:
             self.logger.info(f"Backend '{backend_name}' already exists")
 
         backend_tf_path = os.path.join(self.terraform_dir, "backend.tf")
-        self.cloud_provider.update_backend_config(backend_params, backend_tf_path)
+        self.cloud_provider.write_backend_config(backend_params, backend_tf_path)
 
         self.logger.info("Remote backend setup completed successfully")
         return backend_was_created
@@ -81,8 +81,8 @@ class BackendManager:
             config_source = os.path.basename(self.config_path)
 
         backend_params = self.cloud_provider.get_backend_params(attack_range_id, config_source)
-        backend_name = backend_params["backend_name"]
-        region = backend_params["region"]
+        backend_name = backend_params.backend_name
+        region = backend_params.region
 
         self.logger.info(f"Cleaning up remote backend: {backend_name}")
         self.cloud_provider.delete_backend(backend_name, region)


### PR DESCRIPTION
Exisiting code used polymorhism forcing classes **AWSProvider**, **AzureProvider** and **GCPProvider** to implement set of functions like **create_backend** and **delete_backend**, however I noticed those functions were not used in code, instead **backend_manager** did all logic. I have refactored this to reduce lines of code and utilize existing logic.

Also I have added new dataclass BackendParams. This allows to easily understand what backend configuration consist of and avoid errors like 'KeyError'.

60 lines of code less to maintain :) 

[x] Test passed
[x] Successfully provisioned **splunk_minimal_aws** after changes (in AWS)