### PR TITLE
Ensure E2E AWS cleanup runs when the test step times out.

### DIFF
--- a/.github/workflows/e2e_aws_splunk_windows.yml
+++ b/.github/workflows/e2e_aws_splunk_windows.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   e2e_splunk_windows:
     runs-on: ubuntu-latest
+    # Reserve time after the test step for destroy cleanup (see step timeouts below).
     timeout-minutes: 60
 
     steps:
@@ -50,12 +51,39 @@ jobs:
           pip install pytest "moto[s3]"
 
       - name: Run E2E test (build, verify, destroy)
+        timeout-minutes: 45
         env:
           ATTACK_RANGE_E2E: "1"
           ATTACK_RANGE_CI: "1"
           OBJC_DISABLE_INITIALIZE_FORK_SAFETY: "YES"
         run: |
           pytest tests/e2e/test_splunk_windows_aws.py -v -s --log-cli-level=INFO
+
+      - name: Destroy attack range (cleanup)
+        if: always()
+        timeout-minutes: 10
+        env:
+          ATTACK_RANGE_CI: "1"
+        run: |
+          shopt -s nullglob
+          configs=(config/*.yml)
+          if [ ${#configs[@]} -eq 0 ]; then
+            echo "No config files to destroy."
+            exit 0
+          fi
+          for cfg in "${configs[@]}"; do
+            echo "Destroying attack range from ${cfg}"
+            python attack_range.py destroy --config "${cfg}" || \
+              echo "Destroy failed for ${cfg}; fallback job will retry."
+          done
+
+      - name: Upload config for destroy fallback
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-attack-range-config
+          path: config/
+          if-no-files-found: ignore
 
       - name: Disconnect WireGuard (cleanup)
         if: always()
@@ -64,3 +92,69 @@ jobs:
           if [ -f "$CONF" ]; then
             sudo wg-quick down "$CONF" 2>/dev/null || true
           fi
+
+  destroy_e2e_splunk_windows:
+    needs: e2e_splunk_windows
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends unzip curl
+
+      - name: Install Terraform
+        run: |
+          TERRAFORM_VERSION=1.14.4
+          curl -s "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -o /tmp/terraform.zip
+          unzip -o /tmp/terraform.zip -d /tmp
+          sudo mv /tmp/terraform /usr/local/bin/
+          rm /tmp/terraform.zip
+          terraform version
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Download E2E config artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: e2e-attack-range-config
+          path: config
+
+      - name: Destroy attack range (timeout fallback)
+        env:
+          ATTACK_RANGE_CI: "1"
+        run: |
+          shopt -s nullglob
+          configs=(config/*.yml)
+          if [ ${#configs[@]} -eq 0 ]; then
+            echo "No config files to destroy (test likely cleaned up successfully)."
+            exit 0
+          fi
+          failed=0
+          for cfg in "${configs[@]}"; do
+            echo "Destroying attack range from ${cfg}"
+            if ! python attack_range.py destroy --config "${cfg}"; then
+              echo "Destroy failed for ${cfg} (manual cleanup may be required)"
+              failed=1
+            fi
+          done
+          exit "${failed}"


### PR DESCRIPTION
Cap pytest duration and add always-on destroy steps plus a fallback job so attack ranges are torn down before or after job cancellation.